### PR TITLE
Add theme toggle

### DIFF
--- a/src/app/(admin)/admin/layout.tsx
+++ b/src/app/(admin)/admin/layout.tsx
@@ -11,12 +11,15 @@ import {
   Pencil,
   Search,
   Settings as SettingsIcon,
+  Sun,
+  Moon,
   User,
   X
 } from 'lucide-react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { ReactNode, useState } from 'react';
+import { useTheme } from '@/context/ThemeContext';
 import { Toaster } from 'react-hot-toast';
 
 export default function DashboardLayout({
@@ -26,6 +29,7 @@ export default function DashboardLayout({
 }) {
   const pathname = usePathname();
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const { theme, toggleTheme } = useTheme();
   
   const navItems = [
     { path: '/admin', label: 'Dashboard', icon: Home },
@@ -41,10 +45,10 @@ export default function DashboardLayout({
   };
 
   return (
-    <div className="flex h-screen bg-gray-950 text-gray-100">
+    <div className="flex h-screen bg-gray-50 text-gray-900 dark:bg-gray-950 dark:text-gray-100">
       {/* Sidebar */}
-      <aside className={`${sidebarCollapsed ? 'w-20' : 'w-64'} bg-gray-900/80 backdrop-blur-lg border-r border-gray-800 z-10 transition-all duration-300 ease-in-out`}>
-        <div className="flex items-center justify-between px-4 py-5 border-b border-gray-800">
+      <aside className={`${sidebarCollapsed ? 'w-20' : 'w-64'} bg-gray-100/80 dark:bg-gray-900/80 backdrop-blur-lg border-r border-gray-200 dark:border-gray-800 z-10 transition-all duration-300 ease-in-out`}>
+        <div className="flex items-center justify-between px-4 py-5 border-b border-gray-200 dark:border-gray-800">
           {!sidebarCollapsed && (
             <div className="flex items-center space-x-2">
               <Droplet className="w-6 h-6 text-indigo-400" />
@@ -53,9 +57,9 @@ export default function DashboardLayout({
               </h1>
             </div>
           )}
-          <button 
+          <button
             onClick={toggleSidebar}
-            className="p-1 rounded-md hover:bg-gray-800 text-gray-400 hover:text-gray-200"
+            className="p-1 rounded-md hover:bg-gray-200 dark:hover:bg-gray-800 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200"
           >
             {sidebarCollapsed ? <Menu className="w-5 h-5" /> : <X className="w-5 h-5" />}
           </button>
@@ -68,8 +72,8 @@ export default function DashboardLayout({
               href={path}
               className={`flex items-center w-full px-4 py-3 rounded-lg transition-all group ${
                 pathname === path
-                  ? 'bg-indigo-500/10 text-indigo-400 border-l-4 border-indigo-400' 
-                  : 'text-gray-400 hover:bg-gray-800/50 hover:text-gray-200'
+                  ? 'bg-indigo-100 dark:bg-indigo-500/10 text-indigo-600 dark:text-indigo-400 border-l-4 border-indigo-500 dark:border-indigo-400'
+                  : 'text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-800 hover:text-gray-900 dark:hover:text-gray-200'
               }`}
               title={sidebarCollapsed ? label : undefined}
             >
@@ -78,15 +82,30 @@ export default function DashboardLayout({
                 <span className="font-medium ml-3">{label}</span>
               )}
               {sidebarCollapsed && (
-                <div className="absolute left-full ml-2 px-2 py-1 bg-gray-800 text-white text-sm rounded-md opacity-0 group-hover:opacity-100 whitespace-nowrap">
+                <div className="absolute left-full ml-2 px-2 py-1 bg-gray-200 dark:bg-gray-800 text-gray-900 dark:text-white text-sm rounded-md opacity-0 group-hover:opacity-100 whitespace-nowrap">
                   {label}
                 </div>
               )}
             </Link>
           ))}
+          <button
+            onClick={toggleTheme}
+            className={`flex items-center w-full px-4 py-3 rounded-lg transition-all group text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-800 hover:text-gray-900 dark:hover:text-gray-200 mt-2`}
+            title={sidebarCollapsed ? 'Toggle Theme' : undefined}
+          >
+            {theme === 'dark' ? <Sun className="w-5 h-5" /> : <Moon className="w-5 h-5" />}
+            {!sidebarCollapsed && (
+              <span className="font-medium ml-3">Toggle Theme</span>
+            )}
+            {sidebarCollapsed && (
+              <div className="absolute left-full ml-2 px-2 py-1 bg-gray-200 dark:bg-gray-800 text-gray-900 dark:text-white text-sm rounded-md opacity-0 group-hover:opacity-100 whitespace-nowrap">
+                Toggle Theme
+              </div>
+            )}
+          </button>
         </nav>
         
-        <div className="absolute bottom-0 left-0 right-0 p-4 border-t border-gray-800">
+        <div className="absolute bottom-0 left-0 right-0 p-4 border-t border-gray-200 dark:border-gray-800">
           <div className={`flex items-center ${sidebarCollapsed ? 'justify-center' : 'space-x-3'}`}>
             <div className="w-8 h-8 rounded-full bg-indigo-500/20 flex items-center justify-center">
               <User className="w-4 h-4 text-indigo-400" />
@@ -103,15 +122,15 @@ export default function DashboardLayout({
 
       {/* Main Content */}
       <div className="flex-1 flex flex-col overflow-hidden relative">
-        <header className="flex items-center justify-between px-6 py-4 bg-gray-900/80 backdrop-blur-lg border-b border-gray-800 z-10">
+        <header className="flex items-center justify-between px-6 py-4 bg-gray-100/80 dark:bg-gray-900/80 backdrop-blur-lg border-b border-gray-200 dark:border-gray-800 z-10">
           <div className="flex items-center">
-            <button 
+            <button
               onClick={toggleSidebar}
-              className="mr-4 p-1 rounded-md hover:bg-gray-800 text-gray-400 hover:text-gray-200 md:hidden"
+              className="mr-4 p-1 rounded-md hover:bg-gray-200 dark:hover:bg-gray-800 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 md:hidden"
             >
               <Menu className="w-5 h-5" />
             </button>
-            <h2 className="text-xl font-semibold text-gray-100">
+            <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">
               {navItems.find(item => pathname === item.path)?.label || 'Dashboard'}
             </h2>
           </div>
@@ -122,18 +141,18 @@ export default function DashboardLayout({
               <input
                 type="text"
                 placeholder="Search..."
-                className="pl-10 pr-4 py-2 bg-gray-800 border border-gray-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500 text-gray-200 placeholder-gray-500"
+                className="pl-10 pr-4 py-2 bg-gray-50 dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500 text-gray-900 dark:text-gray-200 placeholder-gray-500"
               />
             </div>
             
-            <button className="relative p-2 rounded-lg bg-gray-800 hover:bg-gray-700 transition-colors">
+            <button className="relative p-2 rounded-lg bg-gray-200 dark:bg-gray-800 hover:bg-gray-300 dark:hover:bg-gray-700 transition-colors">
               <AlertCircle className="w-5 h-5 text-gray-400" />
               <span className="absolute -top-1 -right-1 w-4 h-4 bg-red-500 rounded-full flex items-center justify-center text-xs">
                 3
               </span>
             </button>
             
-            <button className="flex items-center space-x-2 bg-gray-800 hover:bg-gray-700 px-3 py-2 rounded-lg transition-colors">
+            <button className="flex items-center space-x-2 bg-gray-200 dark:bg-gray-800 hover:bg-gray-300 dark:hover:bg-gray-700 px-3 py-2 rounded-lg transition-colors">
               <div className="w-8 h-8 rounded-full bg-indigo-500/20 flex items-center justify-center">
                 <User className="w-4 h-4 text-indigo-400" />
               </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,6 +5,11 @@
   --foreground: #171717;
 }
 
+.dark {
+  --background: #0f0f0f;
+  --foreground: #fafafa;
+}
+
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import { GoogleAnalytics } from "@next/third-parties/google";
 import { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { ThemeProvider } from "@/context/ThemeContext";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -24,8 +25,10 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
-        {children}
+      <body
+        className={`${geistSans.variable} ${geistMono.variable} antialiased bg-white text-gray-900 dark:bg-gray-950 dark:text-gray-100`}
+      >
+        <ThemeProvider>{children}</ThemeProvider>
       </body>
 
       <GoogleAnalytics gaId="G-EPHLVQPHS9" />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,9 +25,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased bg-white text-gray-900 dark:bg-gray-950 dark:text-gray-100`}
-      >
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
         <ThemeProvider>{children}</ThemeProvider>
       </body>
 

--- a/src/components/admin/AnimalInfo.tsx
+++ b/src/components/admin/AnimalInfo.tsx
@@ -142,7 +142,7 @@ export default function AnimalInfo() {
 
             {/* Key Notes */}
             {selectedStage.key_notes && (
-              <div className="p-6 rounded-xl bg-gray-800/50 border border-gray-700 backdrop-blur-sm">
+              <div className="p-6 rounded-xl bg-white/50 dark:bg-gray-800/50 border border-gray-700 backdrop-blur-sm">
                 <h3 className="text-lg font-semibold text-blue-400 mb-3">Key Considerations</h3>
                 <p className="text-gray-300 leading-relaxed">{selectedStage.key_notes}</p>
               </div>
@@ -174,11 +174,11 @@ const NutritionPanel = ({
   requirements,
   colorClass = 'border-blue-500/30 text-blue-400'
 }: NutritionPanelProps) => (
-  <div className="rounded-xl p-6 bg-gray-800/50 border border-gray-700 backdrop-blur-sm">
+  <div className="rounded-xl p-6 bg-white/50 dark:bg-gray-800/50 border border-gray-700 backdrop-blur-sm">
     <h3 className={`text-lg font-semibold ${colorClass} mb-4`}>{title}</h3>
     <div className="grid gap-3">
       {requirements.map((req: AnimalNutrientRequirement) => (
-        <div key={req.nutrientId} className="flex justify-between items-center p-3 hover:bg-gray-700/20 rounded-lg transition-colors">
+        <div key={req.nutrientId} className="flex justify-between items-center p-3 hover:bg-gray-200 dark:hover:bg-gray-700/20 rounded-lg transition-colors">
           <span className="text-gray-300 capitalize">{req.nutrient?.name}</span>
           <span className="text-gray-300">{NutritionPanelValue({ nutrient: req })}</span>
         </div>
@@ -195,7 +195,7 @@ interface OverviewCardProps {
 }
 
 const OverviewCard = ({ title, value, icon }: OverviewCardProps) => (
-  <div className="p-6 rounded-xl bg-gray-800/50 border border-gray-700 backdrop-blur-sm hover:border-blue-400/30 transition-all">
+  <div className="p-6 rounded-xl bg-white/50 dark:bg-gray-800/50 border border-gray-700 backdrop-blur-sm hover:border-blue-400/30 transition-all">
     <div className="flex items-center gap-4">
       <span className="text-2xl">{icon}</span>
       <div>
@@ -228,7 +228,7 @@ const Select = ({
         value={selected}
         disabled={disabled}
         onChange={(e) => onSelect(e.target.value)}
-        className="w-full pl-4 pr-10 py-3 rounded-lg bg-gray-800 border border-gray-700 text-gray-100 
+        className="w-full pl-4 pr-10 py-3 rounded-lg bg-gray-100 dark:bg-gray-800 border border-gray-700 text-gray-100 
                    appearance-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500
                    disabled:opacity-50 disabled:cursor-not-allowed transition-all"
       >

--- a/src/components/admin/DashboardHome.tsx
+++ b/src/components/admin/DashboardHome.tsx
@@ -248,7 +248,7 @@ export function DashboardHome() {
           {recentIngredients.map((ing, index) => (
             <li 
               key={ing.id} 
-              className="flex items-center p-3 bg-gray-100 dark:bg-gray-800/30 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-800/50 transition-colors group"
+              className="flex items-center p-3 bg-gray-100 dark:bg-gray-200/30 dark:bg-gray-800/30 rounded-lg hover:bg-gray-200 dark:hover:bg-white/50 dark:bg-gray-800/50 transition-colors group"
             >
               <div className={`w-3 h-3 rounded-full mr-3 ${BAR_COLORS[index % BAR_COLORS.length]}`}></div>
               <div className="flex-1 min-w-0">

--- a/src/components/admin/DashboardHome.tsx
+++ b/src/components/admin/DashboardHome.tsx
@@ -29,7 +29,7 @@ interface TooltipProps {
 const CustomTooltip = ({ active, payload }: TooltipProps) => {
   if (active && payload && payload.length) {
     return (
-      <div className="bg-gray-800 p-3 border border-gray-700 rounded-lg shadow-lg">
+      <div className="bg-gray-100 dark:bg-gray-800 p-3 border border-gray-300 dark:border-gray-700 rounded-lg shadow-lg">
         <p className="font-medium">{payload[0].payload.category || payload[0].payload.name}</p>
         <p className="text-indigo-300">
           {payload[0].value} {payload[0].name.toLowerCase()}
@@ -79,12 +79,12 @@ export function DashboardHome() {
     .slice(0, 5);
 
   return (
-    <div className="space-y-8 p-6">
+    <div className="space-y-8 p-6 text-gray-900 dark:text-gray-100">
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-white">Dashboard Overview</h1>
-          <p className="text-gray-400">Your feed formulation insights at a glance</p>
+          <h1 className="text-2xl font-bold">Dashboard Overview</h1>
+          <p className="text-gray-600 dark:text-gray-400">Your feed formulation insights at a glance</p>
         </div>
         <div className="flex items-center space-x-2 bg-indigo-900/30 px-4 py-2 rounded-lg">
           <Activity className="w-5 h-5 text-indigo-400" />
@@ -126,17 +126,17 @@ export function DashboardHome() {
         ].map((stat, idx) => (
           <div 
             key={idx} 
-            className="bg-gradient-to-br from-gray-800/50 to-gray-900/50 border border-gray-700 rounded-xl p-5 hover:border-indigo-400/30 transition-all duration-300 hover:scale-[1.02]"
+            className="bg-gradient-to-br from-gray-100 to-gray-200 dark:from-gray-800/50 dark:to-gray-900/50 border border-gray-300 dark:border-gray-700 rounded-xl p-5 hover:border-indigo-400/30 transition-all duration-300 hover:scale-[1.02]"
           >
             <div className="flex items-center justify-between">
               <div className={`p-3 rounded-lg ${stat.color}`}>
-                <stat.icon className="w-6 h-6 text-white" />
+                <stat.icon className="w-6 h-6 text-gray-800 dark:text-white" />
               </div>
               <div className="text-right">
-                <p className="text-3xl font-bold text-white">{stat.value}</p>
+                <p className="text-3xl font-bold">{stat.value}</p>
               </div>
             </div>
-            <h3 className="text-lg font-semibold text-white mt-4">{stat.title}</h3>
+            <h3 className="text-lg font-semibold mt-4">{stat.title}</h3>
             <p className="text-gray-400 text-sm mt-1">{stat.desc}</p>
           </div>
         ))}
@@ -145,13 +145,13 @@ export function DashboardHome() {
       {/* Graphs Section */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Ingredients by Category */}
-        <div className="bg-gradient-to-br from-gray-800/50 to-gray-900/50 border border-gray-700 rounded-xl p-5">
+        <div className="bg-gradient-to-br from-gray-100 to-gray-200 dark:from-gray-800/50 dark:to-gray-900/50 border border-gray-300 dark:border-gray-700 rounded-xl p-5">
           <div className="flex items-center justify-between mb-6">
             <div>
-              <h3 className="text-lg font-semibold text-white">Ingredients by Category</h3>
+              <h3 className="text-lg font-semibold">Ingredients by Category</h3>
               <p className="text-gray-400 text-sm">Distribution of raw materials</p>
             </div>
-            <div className="bg-gray-700/50 px-3 py-1 rounded-full text-sm">
+            <div className="bg-gray-200 dark:bg-gray-700/50 px-3 py-1 rounded-full text-sm">
               {Object.keys(categoryCounts).length} categories
             </div>
           </div>
@@ -182,13 +182,13 @@ export function DashboardHome() {
         </div>
 
         {/* Programs by Species */}
-        <div className="bg-gradient-to-br from-gray-800/50 to-gray-900/50 border border-gray-700 rounded-xl p-5">
+        <div className="bg-gradient-to-br from-gray-100 to-gray-200 dark:from-gray-800/50 dark:to-gray-900/50 border border-gray-300 dark:border-gray-700 rounded-xl p-5">
           <div className="flex items-center justify-between mb-6">
             <div>
-              <h3 className="text-lg font-semibold text-white">Programs by Animal Species</h3>
+              <h3 className="text-lg font-semibold">Programs by Animal Species</h3>
               <p className="text-gray-400 text-sm">Distribution of feeding programs</p>
             </div>
-            <div className="bg-gray-700/50 px-3 py-1 rounded-full text-sm">
+            <div className="bg-gray-200 dark:bg-gray-700/50 px-3 py-1 rounded-full text-sm">
               {programCounts.length} species
             </div>
           </div>
@@ -231,13 +231,13 @@ export function DashboardHome() {
       </div>
 
       {/* Recent Additions */}
-      <div className="bg-gradient-to-br from-gray-800/50 to-gray-900/50 border border-gray-700 rounded-xl p-5">
+      <div className="bg-gradient-to-br from-gray-100 to-gray-200 dark:from-gray-800/50 dark:to-gray-900/50 border border-gray-300 dark:border-gray-700 rounded-xl p-5">
         <div className="flex items-center justify-between mb-4">
           <div>
-            <h3 className="text-lg font-semibold text-white">Recently Added Ingredients</h3>
+            <h3 className="text-lg font-semibold">Recently Added Ingredients</h3>
             <p className="text-gray-400 text-sm">Latest additions to your inventory</p>
           </div>
-          <button className="text-sm text-indigo-400 hover:text-indigo-300 flex items-center">
+          <button className="text-sm text-indigo-600 dark:text-indigo-400 hover:text-indigo-500 dark:hover:text-indigo-300 flex items-center">
             View all
             <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 ml-1" viewBox="0 0 20 20" fill="currentColor">
               <path fillRule="evenodd" d="M10.293 5.293a1 1 0 011.414 0l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414-1.414L12.586 11H5a1 1 0 110-2h7.586l-2.293-2.293a1 1 0 010-1.414z" clipRule="evenodd" />
@@ -248,16 +248,16 @@ export function DashboardHome() {
           {recentIngredients.map((ing, index) => (
             <li 
               key={ing.id} 
-              className="flex items-center p-3 bg-gray-800/30 rounded-lg hover:bg-gray-800/50 transition-colors group"
+              className="flex items-center p-3 bg-gray-100 dark:bg-gray-800/30 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-800/50 transition-colors group"
             >
               <div className={`w-3 h-3 rounded-full mr-3 ${BAR_COLORS[index % BAR_COLORS.length]}`}></div>
               <div className="flex-1 min-w-0">
-                <p className="text-sm font-medium text-white truncate group-hover:text-indigo-300 transition-colors">
+                <p className="text-sm font-medium truncate group-hover:text-indigo-500 dark:group-hover:text-indigo-300 transition-colors">
                   {ing.name}
                 </p>
                 <div className="flex justify-between mt-1">
-                  <p className="text-xs text-gray-400">Category: {ing.category || 'N/A'}</p>
-                  <p className="text-xs text-gray-400">ID: {ing.id}</p>
+                  <p className="text-xs text-gray-600 dark:text-gray-400">Category: {ing.category || 'N/A'}</p>
+                  <p className="text-xs text-gray-600 dark:text-gray-400">ID: {ing.id}</p>
                 </div>
               </div>
             </li>

--- a/src/components/admin/FeedRations/AnimalSelectionModal.tsx
+++ b/src/components/admin/FeedRations/AnimalSelectionModal.tsx
@@ -46,8 +46,8 @@ export const AnimalSelectionModal = ({
       <div className="bg-gray-100 dark:bg-gray-800 border border-gray-700 rounded-xl w-full max-w-3xl max-h-[90vh] flex flex-col shadow-2xl">
         <div className="p-6 flex-1 flex flex-col overflow-hidden">
           {/* Header */}
-          <div className="flex justify-between items-center mb-6">
-            <h3 className="text-lg font-medium text-white">Select Animal Program</h3>
+            <div className="flex justify-between items-center mb-6">
+              <h3 className="text-lg font-medium text-gray-900 dark:text-white">Select Animal Program</h3>
             <button onClick={onClose} className="text-gray-400 hover:text-gray-200">
               <X className="w-5 h-5" />
             </button>
@@ -67,7 +67,7 @@ export const AnimalSelectionModal = ({
             <button
               type="button"
               onClick={onClose}
-              className="px-4 py-2 text-white border border-gray-600 rounded-lg hover:bg-gray-200 dark:bg-gray-700 transition-colors"
+              className="px-4 py-2 text-gray-700 dark:text-gray-200 border border-gray-600 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
             >
               Cancel
             </button>

--- a/src/components/admin/FeedRations/AnimalSelectionModal.tsx
+++ b/src/components/admin/FeedRations/AnimalSelectionModal.tsx
@@ -43,7 +43,7 @@ export const AnimalSelectionModal = ({
 
   return ReactDOM.createPortal(
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4">
-      <div className="bg-gray-800 border border-gray-700 rounded-xl w-full max-w-3xl max-h-[90vh] flex flex-col shadow-2xl">
+      <div className="bg-gray-100 dark:bg-gray-800 border border-gray-700 rounded-xl w-full max-w-3xl max-h-[90vh] flex flex-col shadow-2xl">
         <div className="p-6 flex-1 flex flex-col overflow-hidden">
           {/* Header */}
           <div className="flex justify-between items-center mb-6">
@@ -67,7 +67,7 @@ export const AnimalSelectionModal = ({
             <button
               type="button"
               onClick={onClose}
-              className="px-4 py-2 text-white border border-gray-600 rounded-lg hover:bg-gray-700 transition-colors"
+              className="px-4 py-2 text-white border border-gray-600 rounded-lg hover:bg-gray-200 dark:bg-gray-700 transition-colors"
             >
               Cancel
             </button>

--- a/src/components/admin/FeedRations/BatchCalculation.tsx
+++ b/src/components/admin/FeedRations/BatchCalculation.tsx
@@ -6,13 +6,13 @@ interface BatchCalculationProps {
 }
 
 export const BatchCalculation = ({ ingredients, totalRatio }: BatchCalculationProps) => (
-  <div className="bg-gray-800/50 border border-gray-700 rounded-xl p-6">
+  <div className="bg-white/50 dark:bg-gray-800/50 border border-gray-700 rounded-xl p-6">
     <h3 className="text-lg font-medium mb-4">Batch Calculation (1000kg)</h3>
     <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
       {ingredients.map(ingredient => {
         const pct = totalRatio ? (ingredient.ratio / totalRatio) * 100 : 0;
         return (
-          <div key={ingredient.id} className="bg-gray-700/50 p-3 rounded-lg">
+          <div key={ingredient.id} className="bg-gray-200/50 dark:bg-gray-700/50 p-3 rounded-lg">
             <p className="text-sm text-gray-400">{ingredient.name}</p>
             <p className="text-lg font-medium">
               {((pct / 100) * 1000).toFixed(2)}kg

--- a/src/components/admin/FeedRations/ColumnConfigModal.tsx
+++ b/src/components/admin/FeedRations/ColumnConfigModal.tsx
@@ -48,7 +48,7 @@ export const ColumnConfigModal = ({
 
   return (
     <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4">
-      <div className="bg-gray-800 border border-gray-700 rounded-xl w-full max-w-md max-h-[80vh] flex flex-col">
+      <div className="bg-gray-100 dark:bg-gray-800 border border-gray-700 rounded-xl w-full max-w-md max-h-[80vh] flex flex-col">
         <div className="p-6 flex-grow overflow-hidden flex flex-col">
           <div className="flex justify-between items-center mb-4">
             <h3 className="text-lg font-medium">Configure Columns</h3>
@@ -67,7 +67,7 @@ export const ColumnConfigModal = ({
               placeholder="Search nutrients..."
               value={searchTerm}
               onChange={e => setSearchTerm(e.target.value)}
-              className="w-full pl-10 pr-4 py-2 bg-gray-700/50 border border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500 text-gray-200 placeholder-gray-500"
+              className="w-full pl-10 pr-4 py-2 bg-gray-200/50 dark:bg-gray-700/50 border border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500 text-gray-200 placeholder-gray-500"
             />
           </div>
 
@@ -81,7 +81,7 @@ export const ColumnConfigModal = ({
                       id={`col-${target.id}`}
                       checked={tempVisibleColumns.includes(target.id)}
                       onChange={() => toggleColumn(target.id)}
-                      className="w-4 h-4 text-indigo-600 bg-gray-700 border-gray-600 rounded focus:ring-indigo-500"
+                      className="w-4 h-4 text-indigo-600 bg-gray-200 dark:bg-gray-700 border-gray-600 rounded focus:ring-indigo-500"
                     />
                     <label
                       htmlFor={`col-${target.id}`}
@@ -103,7 +103,7 @@ export const ColumnConfigModal = ({
             <button
               type="button"
               onClick={onClose}
-              className="px-4 py-2 border border-gray-600 rounded-lg hover:bg-gray-700 transition-colors"
+              className="px-4 py-2 border border-gray-600 rounded-lg hover:bg-gray-200 dark:bg-gray-700 transition-colors"
             >
               Cancel
             </button>

--- a/src/components/admin/FeedRations/ContributionChart.tsx
+++ b/src/components/admin/FeedRations/ContributionChart.tsx
@@ -141,7 +141,7 @@ export const ContributionChart: React.FC<ContributionChartProps> = ({
     const actualTotalNormalized = rowData['_actualTotalNormalized'] || 0;
 
     return (
-      <div className="bg-gray-800 border border-gray-700 p-3 rounded-md shadow-lg min-w-[240px]">
+      <div className="bg-gray-100 dark:bg-gray-800 border border-gray-700 p-3 rounded-md shadow-lg min-w-[240px]">
         <h3 className="font-bold text-white mb-2">{label}</h3>
         <div className="mb-2">
           <span className="text-gray-300">Target: </span>
@@ -199,7 +199,7 @@ export const ContributionChart: React.FC<ContributionChartProps> = ({
   const chartHeight = Math.max(360, nutrientData.length * barHeight + 60);
 
   return (
-    <section className="mt-8 p-4 bg-gray-800 rounded-lg shadow mb-4">
+    <section className="mt-8 p-4 bg-gray-100 dark:bg-gray-800 rounded-lg shadow mb-4">
       <div className="flex justify-between items-start mb-4">
         <div>
           <h3 className="text-lg font-semibold text-white">
@@ -209,7 +209,7 @@ export const ContributionChart: React.FC<ContributionChartProps> = ({
             Shows each ingredient's contribution as percentage of target (capped at 100% for display)
           </p>
         </div>
-        <div className="bg-gray-700 px-3 py-1 rounded text-sm text-gray-300">
+        <div className="bg-gray-200 dark:bg-gray-700 px-3 py-1 rounded text-sm text-gray-300">
           100% = Target value
         </div>
       </div>

--- a/src/components/admin/FeedRations/FeedRatiosHeader.tsx
+++ b/src/components/admin/FeedRations/FeedRatiosHeader.tsx
@@ -25,7 +25,7 @@ export const FeedRatiosHeader = ({
     <div className="flex flex-wrap gap-2">
       <button
         onClick={onShowHistory}
-        className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg flex items-center space-x-2"
+        className="px-4 py-2 bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 text-white rounded-lg flex items-center space-x-2"
       >
         <History className="w-4 h-4" />
         <span>Formulations</span>

--- a/src/components/admin/FeedRations/HistoryPanel.tsx
+++ b/src/components/admin/FeedRations/HistoryPanel.tsx
@@ -14,7 +14,7 @@ export const HistoryPanel = ({
   onLoad: (formulation: Formulation) => void;
   onDelete: (id: string) => void;
 }) => (
-  <div className={`fixed inset-y-0 right-0 w-full md:w-96 bg-gray-800 border-l border-gray-700 z-50 transform transition-transform duration-300 ease-in-out ${isOpen ? 'translate-x-0' : 'translate-x-full'}`}>
+  <div className={`fixed inset-y-0 right-0 w-full md:w-96 bg-gray-100 dark:bg-gray-800 border-l border-gray-700 z-50 transform transition-transform duration-300 ease-in-out ${isOpen ? 'translate-x-0' : 'translate-x-full'}`}>
     <div className="p-4 h-full flex flex-col">
       <div className="flex justify-between items-center mb-6">
         <h3 className="text-lg font-semibold">Saved Formulations</h3>
@@ -31,7 +31,7 @@ export const HistoryPanel = ({
         ) : (
           <div className="space-y-3">
             {formulations.map(formulation => (
-              <div key={formulation.id} className="p-3 bg-gray-700/50 rounded-lg border border-gray-600">
+              <div key={formulation.id} className="p-3 bg-gray-200/50 dark:bg-gray-700/50 rounded-lg border border-gray-600">
                 <div className="flex justify-between">
                   <div>
                     <h4 className="font-medium text-white">{formulation.name}</h4>
@@ -40,14 +40,14 @@ export const HistoryPanel = ({
                   <div className="flex space-x-2">
                     <button 
                       onClick={() => onLoad(formulation)}
-                      className="p-1.5 text-green-400 hover:bg-gray-600 rounded"
+                      className="p-1.5 text-green-400 hover:bg-gray-300 dark:hover:bg-gray-600 rounded"
                       title="Load formulation"
                     >
                       <FolderInput className="w-4 h-4" />
                     </button>
                     <button 
                       onClick={() => onDelete(formulation.id)}
-                      className="p-1.5 text-red-400 hover:bg-gray-600 rounded"
+                      className="p-1.5 text-red-400 hover:bg-gray-300 dark:hover:bg-gray-600 rounded"
                       title="Delete formulation"
                     >
                       <Trash2 className="w-4 h-4" />

--- a/src/components/admin/FeedRations/IngredientSelectionModal.tsx
+++ b/src/components/admin/FeedRations/IngredientSelectionModal.tsx
@@ -46,8 +46,8 @@ export const IngredientSelectionModal = ({
 
   return (
     <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4">
-      <div className="bg-gray-800 border border-gray-700 rounded-lg w-full max-w-4xl max-h-[80vh] flex flex-col">
-        <div className="sticky top-0 bg-gray-800 border-b border-gray-700 p-4">
+      <div className="bg-gray-100 dark:bg-gray-800 border border-gray-700 rounded-lg w-full max-w-4xl max-h-[80vh] flex flex-col">
+        <div className="sticky top-0 bg-gray-100 dark:bg-gray-800 border-b border-gray-700 p-4">
           <div className="flex justify-between items-center mb-3">
             <h3 className="text-lg font-semibold text-gray-100">Select Ingredients</h3>
             <button onClick={onClose} className="text-gray-400 hover:text-gray-200 p-1">
@@ -62,7 +62,7 @@ export const IngredientSelectionModal = ({
               placeholder="Filter ingredients..."
               value={searchTerm}
               onChange={handleSearch}
-              className="w-full pl-10 pr-4 py-2 bg-gray-900 rounded-lg text-gray-200 focus:ring-2 focus:ring-indigo-500 border border-gray-700"
+              className="w-full pl-10 pr-4 py-2 bg-white dark:bg-gray-900 rounded-lg text-gray-200 focus:ring-2 focus:ring-indigo-500 border border-gray-700"
             />
           </div>
 
@@ -73,7 +73,7 @@ export const IngredientSelectionModal = ({
             {targets.filter(t => visibleColumns.includes(t.id)).map(target => (
               <div
                 key={target.id}
-                className="col-span-2 flex items-center justify-end space-x-1 cursor-pointer hover:bg-gray-700/30 p-1 rounded"
+                className="col-span-2 flex items-center justify-end space-x-1 cursor-pointer hover:bg-gray-200 dark:hover:bg-gray-700/30 p-1 rounded"
               >
                 <span className="text-sm font-medium text-gray-400">
                   {target.name}
@@ -90,7 +90,7 @@ export const IngredientSelectionModal = ({
               .map(ingredient => (
                 <div
                   key={ingredient.id}
-                  className="grid grid-cols-12 gap-4 items-center p-3 rounded-lg hover:bg-gray-700/30 cursor-pointer"
+                  className="grid grid-cols-12 gap-4 items-center p-3 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700/30 cursor-pointer"
                   onClick={() => addIngredient(ingredient)}
                 >
                   <div className="col-span-4">
@@ -116,11 +116,11 @@ export const IngredientSelectionModal = ({
           </div>
         </div>
 
-        <div className="sticky bottom-0 bg-gray-800 border-t border-gray-700 p-4">
+        <div className="sticky bottom-0 bg-gray-100 dark:bg-gray-800 border-t border-gray-700 p-4">
           <div className="flex justify-between items-center space-x-4">
             <button
               onClick={onClose}
-              className="px-6 py-2.5 text-gray-300 hover:text-white hover:bg-gray-700/50 rounded-lg transition-colors"
+              className="px-6 py-2.5 text-gray-300 hover:text-white hover:bg-gray-200/50 dark:bg-gray-700/50 rounded-lg transition-colors"
             >
               Cancel
             </button>

--- a/src/components/admin/FeedRations/IngredientsPanel.tsx
+++ b/src/components/admin/FeedRations/IngredientsPanel.tsx
@@ -32,7 +32,7 @@ export const IngredientsPanel = ({
   onOpenColumnConfig,
   onOpenIngredientModal
 }: IngredientsPanelProps) => (
-  <div className="bg-gray-800/50 border border-gray-700 rounded-xl p-6 mb-4">
+  <div className="bg-white/50 dark:bg-gray-800/50 border border-gray-700 rounded-xl p-6 mb-4">
     <div className="flex justify-between items-center mb-4">
       <h3 className="text-lg font-medium">Ingredient Composition</h3>
       <div className="flex items-center gap-2">
@@ -44,20 +44,20 @@ export const IngredientsPanel = ({
         )}
         <button
           onClick={onOpenSaveModal}
-          className="p-2 text-gray-400 hover:bg-gray-700 rounded-md"
+          className="p-2 text-gray-400 hover:bg-gray-200 dark:bg-gray-700 rounded-md"
           title="Save formulation"
         >
           <Save className="w-5 h-5" />
         </button>
         <button
           onClick={onOpenColumnConfig}
-          className="p-2 text-gray-400 hover:bg-gray-700 rounded-md"
+          className="p-2 text-gray-400 hover:bg-gray-200 dark:bg-gray-700 rounded-md"
         >
           <Settings className="w-5 h-5" />
         </button>
         <button
           onClick={onOpenIngredientModal}
-          className="p-2 text-gray-400 hover:bg-gray-700 rounded-md"
+          className="p-2 text-gray-400 hover:bg-gray-200 dark:bg-gray-700 rounded-md"
         >
           <Plus className="w-5 h-5" />
         </button>
@@ -69,7 +69,7 @@ export const IngredientsPanel = ({
     ) : (
       <div className="overflow-x-auto">
         <table className="min-w-full divide-y divide-gray-700">
-          <thead className="bg-gray-700/50">
+          <thead className="bg-gray-200/50 dark:bg-gray-700/50">
             <tr>
               <th className="px-4 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">Ingredient</th>
               <th className="px-4 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">Ratio</th>
@@ -91,7 +91,7 @@ export const IngredientsPanel = ({
             {ingredients.map(ingredient => {
               const pct = totalRatio ? (ingredient.ratio / totalRatio) * 100 : 0;
               return (
-                <tr key={ingredient.id} className="hover:bg-gray-700/50">
+                <tr key={ingredient.id} className="hover:bg-gray-200/50 dark:bg-gray-700/50">
                   <td className="px-4 py-3 text-gray-200">{ingredient.name}</td>
                   <td className="px-4 py-3">
                     <input
@@ -100,7 +100,7 @@ export const IngredientsPanel = ({
                       step={0.0001}
                       value={ingredient.ratio}
                       onChange={e => handleRatioChange(ingredient.id, e.target.value)}
-                      className="w-20 px-2 py-1 bg-gray-700 border border-gray-600 rounded text-gray-200"
+                      className="w-20 px-2 py-1 bg-gray-200 dark:bg-gray-700 border border-gray-600 rounded text-gray-200"
                     />
                   </td>
                   <td className="px-4 py-3">
@@ -110,7 +110,7 @@ export const IngredientsPanel = ({
                       step={0.01}
                       value={ingredient.costPerKg ?? ''}
                       onChange={e => handleCostChange(ingredient.id, e.target.value)}
-                      className="w-24 px-2 py-1 bg-gray-700 border border-gray-600 rounded text-gray-200"
+                      className="w-24 px-2 py-1 bg-gray-200 dark:bg-gray-700 border border-gray-600 rounded text-gray-200"
                     />
                   </td>
                   <td className="px-4 py-3 text-gray-200">{pct.toFixed(1)}%</td>
@@ -121,7 +121,7 @@ export const IngredientsPanel = ({
                       max={100}
                       value={ingredient.min ?? ''}
                       onChange={e => handleMinChange(ingredient.id, e.target.value)}
-                      className="w-16 bg-gray-800 border border-gray-700 rounded px-2 py-1 text-sm"
+                      className="w-16 bg-gray-100 dark:bg-gray-800 border border-gray-700 rounded px-2 py-1 text-sm"
                       placeholder="Min"
                     />
                   </td>
@@ -133,7 +133,7 @@ export const IngredientsPanel = ({
                       max={100}
                       value={ingredient.max ?? ''}
                       onChange={e => handleMaxChange(ingredient.id, e.target.value)}
-                      className="w-16 bg-gray-800 border border-gray-700 rounded px-2 py-1 text-sm"
+                      className="w-16 bg-gray-100 dark:bg-gray-800 border border-gray-700 rounded px-2 py-1 text-sm"
                       placeholder="Max"
                     />
                   </td>

--- a/src/components/admin/FeedRations/SaveFormulationModal.tsx
+++ b/src/components/admin/FeedRations/SaveFormulationModal.tsx
@@ -34,7 +34,7 @@ export const SaveFormulationModal = ({
 
   return (
     <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4">
-      <div className="bg-gray-800 border border-gray-700 rounded-xl w-full max-w-md">
+      <div className="bg-gray-100 dark:bg-gray-800 border border-gray-700 rounded-xl w-full max-w-md">
         <div className="p-6">
           <div className="flex justify-between items-center mb-4">
             <h3 className="text-lg font-medium">Save Formulation</h3>
@@ -55,7 +55,7 @@ export const SaveFormulationModal = ({
               id="formulation-name"
               value={name}
               onChange={(e) => setName(e.target.value)}
-              className="w-full px-4 py-2 bg-gray-700 border border-gray-600 rounded-lg text-gray-200 focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
+              className="w-full px-4 py-2 bg-gray-200 dark:bg-gray-700 border border-gray-600 rounded-lg text-gray-200 focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
               placeholder="Enter a name for this formulation"
               autoFocus
             />
@@ -65,7 +65,7 @@ export const SaveFormulationModal = ({
             <button
               type="button"
               onClick={onClose}
-              className="px-4 py-2 border border-gray-600 rounded-lg hover:bg-gray-700 transition-colors"
+              className="px-4 py-2 border border-gray-600 rounded-lg hover:bg-gray-200 dark:bg-gray-700 transition-colors"
             >
               Cancel
             </button>

--- a/src/components/admin/FeedRations/SuggestedIngredients.tsx
+++ b/src/components/admin/FeedRations/SuggestedIngredients.tsx
@@ -52,7 +52,7 @@ export const SuggestedIngredients = ({
   };
 
   return (
-    <div className="bg-gray-800/50 border border-gray-700 rounded-xl p-6 mb-4">
+    <div className="bg-white/50 dark:bg-gray-800/50 border border-gray-700 rounded-xl p-6 mb-4">
       <div className="flex items-center gap-2 mb-4">
         <Lightbulb className="h-5 w-5 text-yellow-400" />
         <h3 className="text-lg font-medium">Nutrient Suggestions</h3>
@@ -60,7 +60,7 @@ export const SuggestedIngredients = ({
 
       <div className="space-y-4">
         {suggestions.map((suggestion, index) => (
-          <div key={index} className="bg-gray-800 rounded-lg p-4 border border-gray-700">
+          <div key={index} className="bg-gray-100 dark:bg-gray-800 rounded-lg p-4 border border-gray-700">
             <div className="flex justify-between items-start">
               <div>
                 {'nutrient' in suggestion ? (
@@ -115,7 +115,7 @@ export const SuggestedIngredients = ({
                 <p className="text-sm text-gray-300 mb-2">High sources of {suggestion.nutrient.name}:</p>
                 <div className="space-y-2">
                   {findNutrientSources(suggestion.nutrient.name).map((ingredient) => (
-                    <div key={ingredient.id} className="flex justify-between items-center bg-gray-700/50 rounded p-2">
+                    <div key={ingredient.id} className="flex justify-between items-center bg-gray-200/50 dark:bg-gray-700/50 rounded p-2">
                       <div>
                         <span className="text-sm">{ingredient.name}</span>
                         <span className="text-xs text-gray-400 ml-2">

--- a/src/components/admin/FeedRations/TargetInputItem.tsx
+++ b/src/components/admin/FeedRations/TargetInputItem.tsx
@@ -35,7 +35,7 @@ export const TargetInputItem = ({
             value={target.target ?? ''}
             onChange={(e) => handleChange('target', e)}
             placeholder="Min"
-            className="w-full pl-2 pr-6 py-1 bg-gray-800 border border-gray-600 rounded-md text-gray-200 text-sm focus:ring-1 focus:ring-indigo-500"
+            className="w-full pl-2 pr-6 py-1 bg-gray-100 dark:bg-gray-800 border border-gray-600 rounded-md text-gray-200 text-sm focus:ring-1 focus:ring-indigo-500"
           />
           <span className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 text-sm">
             {target.unit}
@@ -51,7 +51,7 @@ export const TargetInputItem = ({
             value={target.max ?? ''}
             onChange={(e) => handleChange('max', e)}
             placeholder="Max"
-            className="w-full pl-2 pr-6 py-1 bg-gray-800 border border-gray-600 rounded-md text-gray-200 text-sm focus:ring-1 focus:ring-indigo-500"
+            className="w-full pl-2 pr-6 py-1 bg-gray-100 dark:bg-gray-800 border border-gray-600 rounded-md text-gray-200 text-sm focus:ring-1 focus:ring-indigo-500"
           />
           <span className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 text-sm">
             {target.unit}
@@ -61,7 +61,7 @@ export const TargetInputItem = ({
         {/* Penalty toggle */}
         <button
           onClick={() => setShowPenalties(!showPenalties)}
-          className="ml-auto px-2 py-1 text-xs bg-gray-700 hover:bg-gray-600 rounded-md transition-colors"
+          className="ml-auto px-2 py-1 text-xs bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 rounded-md transition-colors"
           aria-label={showPenalties ? "Hide penalties" : "Show penalties"}
         >
           {showPenalties ? "▲ Penalties" : "▼ Penalties"}
@@ -91,7 +91,7 @@ export const TargetInputItem = ({
               value={target.underPenaltyFactor ?? ''}
               onChange={(e) => handleChange('underPenaltyFactor', e)}
               placeholder={`Default (${DEFAULT_UNDER_PENALTY})`}
-              className="w-full pl-2 pr-2 py-1 bg-gray-800 border border-gray-600 rounded-md text-gray-200 text-sm"
+              className="w-full pl-2 pr-2 py-1 bg-gray-100 dark:bg-gray-800 border border-gray-600 rounded-md text-gray-200 text-sm"
             />
           </div>
           <div>
@@ -105,7 +105,7 @@ export const TargetInputItem = ({
               value={target.overPenaltyFactor ?? ''}
               onChange={(e) => handleChange('overPenaltyFactor', e)}
               placeholder={`Default (${DEFAULT_OVER_PENALTY})`}
-              className="w-full pl-2 pr-2 py-1 bg-gray-800 border border-gray-600 rounded-md text-gray-200 text-sm"
+              className="w-full pl-2 pr-2 py-1 bg-gray-100 dark:bg-gray-800 border border-gray-600 rounded-md text-gray-200 text-sm"
             />
           </div>
           <div className="col-span-2 text-xs text-gray-500 mt-1">

--- a/src/components/admin/FeedRations/TargetResultItem.tsx
+++ b/src/components/admin/FeedRations/TargetResultItem.tsx
@@ -6,7 +6,7 @@ const ProgressBar = ({ value, target, met }: {
   max?: number;
   met: boolean;
 }) => (
-  <div className="mt-2 h-1.5 bg-gray-700 rounded-full overflow-hidden">
+  <div className="mt-2 h-1.5 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
     <div
       className="h-full rounded-full transition-all duration-300"
       style={{

--- a/src/components/admin/FeedRations/TargetSelectionModal.tsx
+++ b/src/components/admin/FeedRations/TargetSelectionModal.tsx
@@ -21,8 +21,8 @@ export const TargetSelectionModal = ({
 
   return (
     <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4">
-      <div className="bg-gray-800 border border-gray-700 rounded-lg w-full max-w-md flex flex-col max-h-[90vh]">
-        <div className="sticky top-0 bg-gray-800 border-b border-gray-700 p-4 space-y-4">
+      <div className="bg-gray-100 dark:bg-gray-800 border border-gray-700 rounded-lg w-full max-w-md flex flex-col max-h-[90vh]">
+        <div className="sticky top-0 bg-gray-100 dark:bg-gray-800 border-b border-gray-700 p-4 space-y-4">
           <div className="flex justify-between items-center">
             <h3 className="text-lg font-semibold text-gray-100">
               Add Nutrient Targets
@@ -40,7 +40,7 @@ export const TargetSelectionModal = ({
             <input
               type="text"
               placeholder="Search nutrients..."
-              className="w-full pl-10 pr-4 py-2.5 bg-gray-900 border border-gray-700 rounded-lg text-gray-200 focus:ring-2 focus:ring-cyan-500 focus:border-transparent"
+              className="w-full pl-10 pr-4 py-2.5 bg-white dark:bg-gray-900 border border-gray-700 rounded-lg text-gray-200 focus:ring-2 focus:ring-cyan-500 focus:border-transparent"
               autoFocus
             />
           </div>
@@ -52,7 +52,7 @@ export const TargetSelectionModal = ({
             .map(nutrient => (
               <div
                 key={nutrient.id}
-                className="flex items-center justify-between p-3 rounded-lg hover:bg-gray-700/30 cursor-pointer"
+                className="flex items-center justify-between p-3 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700/30 cursor-pointer"
                 onClick={() => addTargets([{ 
                   id: nutrient.id, 
                   name: nutrient.name, 
@@ -68,11 +68,11 @@ export const TargetSelectionModal = ({
             ))}
         </div>
 
-        <div className="sticky bottom-0 bg-gray-800 border-t border-gray-700 p-4">
+        <div className="sticky bottom-0 bg-gray-100 dark:bg-gray-800 border-t border-gray-700 p-4">
           <div className="flex justify-between items-center">
             <button
               onClick={onClose}
-              className="px-4 py-2.5 text-gray-300 hover:text-white hover:bg-gray-700/50 rounded-lg transition-colors"
+              className="px-4 py-2.5 text-gray-300 hover:text-white hover:bg-gray-200/50 dark:bg-gray-700/50 rounded-lg transition-colors"
             >
               Cancel
             </button>

--- a/src/components/admin/FeedRations/TargetSelectionModal.tsx
+++ b/src/components/admin/FeedRations/TargetSelectionModal.tsx
@@ -23,8 +23,8 @@ export const TargetSelectionModal = ({
     <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4">
       <div className="bg-gray-100 dark:bg-gray-800 border border-gray-700 rounded-lg w-full max-w-md flex flex-col max-h-[90vh]">
         <div className="sticky top-0 bg-gray-100 dark:bg-gray-800 border-b border-gray-700 p-4 space-y-4">
-          <div className="flex justify-between items-center">
-            <h3 className="text-lg font-semibold text-gray-100">
+            <div className="flex justify-between items-center">
+              <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
               Add Nutrient Targets
             </h3>
             <button
@@ -37,10 +37,10 @@ export const TargetSelectionModal = ({
 
           <div className="relative">
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
-            <input
-              type="text"
-              placeholder="Search nutrients..."
-              className="w-full pl-10 pr-4 py-2.5 bg-white dark:bg-gray-900 border border-gray-700 rounded-lg text-gray-200 focus:ring-2 focus:ring-cyan-500 focus:border-transparent"
+              <input
+                type="text"
+                placeholder="Search nutrients..."
+                className="w-full pl-10 pr-4 py-2.5 bg-white dark:bg-gray-900 border border-gray-700 rounded-lg text-gray-900 dark:text-gray-200 focus:ring-2 focus:ring-cyan-500 focus:border-transparent"
               autoFocus
             />
           </div>
@@ -61,18 +61,18 @@ export const TargetSelectionModal = ({
                   description: nutrient.description || '' 
                 }])}
               >
-                <div className="flex items-center space-x-3">
-                  <span className="text-gray-200 truncate">{nutrient.name}</span>
+                  <div className="flex items-center space-x-3">
+                    <span className="text-gray-700 dark:text-gray-200 truncate">{nutrient.name}</span>
                 </div>
               </div>
             ))}
         </div>
 
-        <div className="sticky bottom-0 bg-gray-100 dark:bg-gray-800 border-t border-gray-700 p-4">
-          <div className="flex justify-between items-center">
-            <button
-              onClick={onClose}
-              className="px-4 py-2.5 text-gray-300 hover:text-white hover:bg-gray-200/50 dark:bg-gray-700/50 rounded-lg transition-colors"
+          <div className="sticky bottom-0 bg-gray-100 dark:bg-gray-800 border-t border-gray-700 p-4">
+            <div className="flex justify-between items-center">
+              <button
+                onClick={onClose}
+                className="px-4 py-2.5 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700/50 rounded-lg transition-colors"
             >
               Cancel
             </button>

--- a/src/components/admin/FeedRations/TargetsPanel.tsx
+++ b/src/components/admin/FeedRations/TargetsPanel.tsx
@@ -41,7 +41,7 @@ export const TargetsPanel = ({
   }, [computedValues, targets]);
 
   return (
-    <div className="bg-gray-800/50 border border-gray-700 rounded-xl p-4">
+    <div className="bg-white/50 dark:bg-gray-800/50 border border-gray-700 rounded-xl p-4">
       <div className="flex justify-between items-center mb-4">
         <div className="flex items-center gap-2">
           <h3 className="text-lg font-semibold text-gray-100">Nutrient Targets</h3>
@@ -61,7 +61,7 @@ export const TargetsPanel = ({
         <div className="flex items-center gap-2">
           <button
             onClick={onOpenAnimalModal}
-            className="p-2 text-white hover:bg-gray-700 rounded-md"
+            className="p-2 text-white hover:bg-gray-200 dark:bg-gray-700 rounded-md"
             title="Select animal program"
             type="button"
           >
@@ -69,7 +69,7 @@ export const TargetsPanel = ({
           </button>
           <button
             onClick={onOpenTargetModal}
-            className="p-2 text-gray-400 hover:bg-gray-700 rounded-md"
+            className="p-2 text-gray-400 hover:bg-gray-200 dark:bg-gray-700 rounded-md"
           >
             <Plus className="w-5 h-5" />
           </button>

--- a/src/components/admin/IngredientDetails.tsx
+++ b/src/components/admin/IngredientDetails.tsx
@@ -51,7 +51,7 @@ const NutrientTable = ({ data, nutrientRankings }: { data: Composition[]; nutrie
   return (
     <div className="overflow-hidden rounded-lg border border-gray-700">
       <table className="min-w-full divide-y divide-gray-700">
-        <thead className="bg-gray-800">
+        <thead className="bg-gray-100 dark:bg-gray-800">
           <tr>
             <th className="px-4 py-3 text-left text-sm font-medium text-gray-300">Nutrient</th>
             <th className="px-4 py-3 text-left text-sm font-medium text-gray-300">Value</th>
@@ -70,7 +70,7 @@ const NutrientTable = ({ data, nutrientRankings }: { data: Composition[]; nutrie
             return (
               <tr 
                 key={comp.nutrientId} 
-                className={index % 2 === 0 ? 'bg-gray-800' : 'bg-gray-900'}
+                className={index % 2 === 0 ? 'bg-gray-100 dark:bg-gray-800' : 'bg-white dark:bg-gray-900'}
               >
                 <td className="px-4 py-3 text-gray-300">{comp.nutrient?.name}</td>
                 <td className="px-4 py-3 text-gray-300">{comp.value}</td>
@@ -129,7 +129,7 @@ const NutrientCategoryWidget = ({
   }, [data]);
 
   return (
-    <div className="bg-gray-800/50 rounded-2xl p-6 border border-gray-700 flex flex-col h-full">
+    <div className="bg-white/50 dark:bg-gray-800/50 rounded-2xl p-6 border border-gray-700 flex flex-col h-full">
       <h3 className="text-xl font-semibold text-white mb-4">{title}</h3>
       
       <div className="flex-grow overflow-auto">
@@ -150,7 +150,7 @@ const NutrientCategoryWidget = ({
             ) : (
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
                 {unitData.map((comp) => (
-                  <div key={comp.nutrientId} className="bg-gray-800/50 p-4 rounded-xl border border-gray-700">
+                  <div key={comp.nutrientId} className="bg-white/50 dark:bg-gray-800/50 p-4 rounded-xl border border-gray-700">
                     <div className="text-sm text-gray-400">{comp.nutrient?.name}</div>
                     <div className="text-xl font-bold text-white">
                       {comp.value} {comp.nutrient?.unit || 'g/kg'}
@@ -183,7 +183,7 @@ const TopNutrientsWidget = ({ data }: { data: Composition[] }) => {
   }, [data]);
 
   return (
-    <div className="bg-gray-800/50 rounded-2xl p-6 border border-gray-700">
+    <div className="bg-white/50 dark:bg-gray-800/50 rounded-2xl p-6 border border-gray-700">
       <h3 className="text-xl font-semibold text-white mb-4">
         Nutrient Strengths
         <span className="text-sm text-gray-400 ml-2 font-normal">(vs average ingredients)</span>
@@ -201,7 +201,7 @@ const TopNutrientsWidget = ({ data }: { data: Composition[] }) => {
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ delay: index * 0.1 }}
-              className="flex items-center justify-between bg-gray-800/50 p-4 rounded-lg border border-gray-700"
+              className="flex items-center justify-between bg-white/50 dark:bg-gray-800/50 p-4 rounded-lg border border-gray-700"
             >
               <div className="flex items-center">
                 <div className="w-8 h-8 rounded-full bg-indigo-500/20 flex items-center justify-center mr-3">
@@ -366,7 +366,7 @@ export function IngredientDetails({ id }: { id: string }) {
 
       {/* Header Section */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-12">
-        <div className="bg-gray-800/50 rounded-2xl p-6 border border-gray-700 flex flex-col justify-center">
+        <div className="bg-white/50 dark:bg-gray-800/50 rounded-2xl p-6 border border-gray-700 flex flex-col justify-center">
           <div className="flex justify-between items-start mb-4">
             <div>
               <h1 className="text-3xl md:text-4xl font-bold text-white mb-2">
@@ -391,7 +391,7 @@ export function IngredientDetails({ id }: { id: string }) {
                 initial={{ opacity: 0, y: 20 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ delay: index * 0.1 }}
-                className="bg-gray-800/50 p-4 rounded-xl border border-gray-700"
+                className="bg-white/50 dark:bg-gray-800/50 p-4 rounded-xl border border-gray-700"
               >
                 <div className="flex justify-between items-start">
                   <div>
@@ -419,7 +419,7 @@ export function IngredientDetails({ id }: { id: string }) {
           </div>
         </div>
         
-        <div className="bg-gray-800/50 rounded-2xl p-6 border border-gray-700">
+        <div className="bg-white/50 dark:bg-gray-800/50 rounded-2xl p-6 border border-gray-700">
           <h2 className="text-2xl font-bold text-white mb-6">Macronutrient Distribution</h2>
           <div className="h-80">
             <ResponsiveContainer width="100%" height="100%">
@@ -479,12 +479,12 @@ export function IngredientDetails({ id }: { id: string }) {
         <h2 className="text-2xl font-bold text-white mb-6">Scientific Analysis</h2>
         
         <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-          <div className="bg-gray-800/50 rounded-2xl p-6 border border-gray-700">
+          <div className="bg-white/50 dark:bg-gray-800/50 rounded-2xl p-6 border border-gray-700">
             <h3 className="text-xl font-semibold text-white mb-4">Digestibility</h3>
             <div className="space-y-4">
               <div>
                 <h4 className="font-medium text-white">Protein Digestibility</h4>
-                <div className="w-full bg-gray-700 rounded-full h-2.5 mt-2">
+                <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2.5 mt-2">
                   <div 
                     className="bg-indigo-500 h-2.5 rounded-full" 
                     style={{ width: '85%' }}
@@ -495,7 +495,7 @@ export function IngredientDetails({ id }: { id: string }) {
               
               <div>
                 <h4 className="font-medium text-white">Energy Utilization</h4>
-                <div className="w-full bg-gray-700 rounded-full h-2.5 mt-2">
+                <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2.5 mt-2">
                   <div 
                     className="bg-indigo-500 h-2.5 rounded-full" 
                     style={{ width: '78%' }}
@@ -506,7 +506,7 @@ export function IngredientDetails({ id }: { id: string }) {
             </div>
           </div>
           
-          <div className="bg-gray-800/50 rounded-2xl p-6 border border-gray-700">
+          <div className="bg-white/50 dark:bg-gray-800/50 rounded-2xl p-6 border border-gray-700">
             <h3 className="text-xl font-semibold text-white mb-4">Amino Acid Profile</h3>
             <div className="space-y-3">
               {[
@@ -520,7 +520,7 @@ export function IngredientDetails({ id }: { id: string }) {
                     <span className="text-gray-300">{aa.name}</span>
                     <span className="text-gray-400">{aa.value}g/100g protein</span>
                   </div>
-                  <div className="w-full bg-gray-700 rounded-full h-2">
+                  <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2">
                     <div 
                       className={`h-2 rounded-full ${aa.value >= aa.ideal ? 'bg-green-500' : 'bg-amber-500'}`} 
                       style={{ width: `${Math.min(100, (aa.value / aa.ideal) * 100)}%` }}
@@ -534,7 +534,7 @@ export function IngredientDetails({ id }: { id: string }) {
       </div>
 
       {/* Research Studies */}
-      <div className="bg-gray-800/50 rounded-2xl p-6 border border-gray-700 mb-16">
+      <div className="bg-white/50 dark:bg-gray-800/50 rounded-2xl p-6 border border-gray-700 mb-16">
         <h2 className="text-2xl font-bold text-white mb-6">Research Studies</h2>
         
         <div className="space-y-6">

--- a/src/components/admin/IngredientList.tsx
+++ b/src/components/admin/IngredientList.tsx
@@ -59,7 +59,7 @@ const ColumnConfigModal = ({
 
   return (
     <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4">
-      <div className="bg-gray-800 border border-gray-700 rounded-xl w-full max-w-md max-h-[80vh] flex flex-col">
+      <div className="bg-gray-100 dark:bg-gray-800 border border-gray-700 rounded-xl w-full max-w-md max-h-[80vh] flex flex-col">
         <div className="p-6 flex-grow overflow-hidden flex flex-col">
           <div className="flex justify-between items-center mb-4">
             <h3 className="text-lg font-medium">Configure Nutrient Columns</h3>
@@ -78,7 +78,7 @@ const ColumnConfigModal = ({
               placeholder="Search nutrients..."
               value={searchTerm}
               onChange={e => setSearchTerm(e.target.value)}
-              className="w-full pl-10 pr-4 py-2 bg-gray-700/50 border border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500 text-gray-200 placeholder-gray-500"
+              className="w-full pl-10 pr-4 py-2 bg-gray-200/50 dark:bg-gray-700/50 border border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500 text-gray-200 placeholder-gray-500"
             />
           </div>
           
@@ -92,7 +92,7 @@ const ColumnConfigModal = ({
                       id={`col-${nutrient.id}`}
                       checked={tempVisibleColumns.includes(nutrient.id)}
                       onChange={() => toggleColumn(nutrient.id)}
-                      className="w-4 h-4 text-indigo-600 bg-gray-700 border-gray-600 rounded focus:ring-indigo-500"
+                      className="w-4 h-4 text-indigo-600 bg-gray-200 dark:bg-gray-700 border-gray-600 rounded focus:ring-indigo-500"
                     />
                     <label 
                       htmlFor={`col-${nutrient.id}`} 
@@ -120,7 +120,7 @@ const ColumnConfigModal = ({
             <button
               type="button"
               onClick={onClose}
-              className="px-4 py-2 border border-gray-600 rounded-lg hover:bg-gray-700 transition-colors"
+              className="px-4 py-2 border border-gray-600 rounded-lg hover:bg-gray-200 dark:bg-gray-700 transition-colors"
             >
               Cancel
             </button>
@@ -191,7 +191,7 @@ const FilterModal = ({
 
   return (
     <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4">
-      <div className="bg-gray-800 border border-gray-700 rounded-xl w-full max-w-md max-h-[80vh] flex flex-col">
+      <div className="bg-gray-100 dark:bg-gray-800 border border-gray-700 rounded-xl w-full max-w-md max-h-[80vh] flex flex-col">
         <div className="p-6 flex-grow overflow-hidden flex flex-col">
           <div className="flex justify-between items-center mb-4">
             <h3 className="text-lg font-medium">Filter by Category</h3>
@@ -210,7 +210,7 @@ const FilterModal = ({
               placeholder="Search categories..."
               value={searchTerm}
               onChange={e => setSearchTerm(e.target.value)}
-              className="w-full pl-10 pr-4 py-2 bg-gray-700/50 border border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500 text-gray-200 placeholder-gray-500"
+              className="w-full pl-10 pr-4 py-2 bg-gray-200/50 dark:bg-gray-700/50 border border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500 text-gray-200 placeholder-gray-500"
             />
           </div>
           
@@ -224,7 +224,7 @@ const FilterModal = ({
                       id={`cat-${category}`}
                       checked={tempSelected.includes(category)}
                       onChange={() => toggleCategory(category)}
-                      className="w-4 h-4 text-indigo-600 bg-gray-700 border-gray-600 rounded focus:ring-indigo-500"
+                      className="w-4 h-4 text-indigo-600 bg-gray-200 dark:bg-gray-700 border-gray-600 rounded focus:ring-indigo-500"
                     />
                     <label 
                       htmlFor={`cat-${category}`} 
@@ -254,7 +254,7 @@ const FilterModal = ({
               <button
                 type="button"
                 onClick={onClose}
-                className="px-4 py-2 border border-gray-600 rounded-lg hover:bg-gray-700 transition-colors"
+                className="px-4 py-2 border border-gray-600 rounded-lg hover:bg-gray-200 dark:bg-gray-700 transition-colors"
               >
                 Cancel
               </button>
@@ -308,7 +308,7 @@ const IngredientRow = ({
 }) => (
   <>
     <tr
-      className="hover:bg-gray-700/50 transition-colors cursor-pointer"
+      className="hover:bg-gray-200/50 dark:bg-gray-700/50 transition-colors cursor-pointer"
     >
       <td className="px-6 py-4 whitespace-nowrap font-medium text-gray-200">{ingredient.name}</td>
       <td className="px-6 py-4 whitespace-nowrap">{ingredient.category}</td>
@@ -349,7 +349,7 @@ const SearchBar = ({
       placeholder="Search ingredients or categories..."
       value={searchTerm}
       onChange={e => setSearchTerm(e.target.value)}
-      className="w-full pl-10 pr-4 py-2 bg-gray-800 border border-gray-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500 text-gray-200 placeholder-gray-500"
+      className="w-full pl-10 pr-4 py-2 bg-gray-100 dark:bg-gray-800 border border-gray-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500 text-gray-200 placeholder-gray-500"
     />
   </div>
 );
@@ -506,14 +506,14 @@ export const IngredientList = () => {
         <div className="flex gap-4">
           <button 
             onClick={() => setShowColumnConfig(true)}
-            className="px-4 py-2 bg-gray-800 hover:bg-gray-700 border border-gray-700 rounded-lg flex items-center space-x-2 transition-colors"
+            className="px-4 py-2 bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:bg-gray-700 border border-gray-700 rounded-lg flex items-center space-x-2 transition-colors"
           >
             <Settings className="w-4 h-4 text-gray-400" />
             <span>Columns</span>
           </button>
           <button 
             onClick={() => setShowFilterModal(true)}
-            className="px-4 py-2 bg-gray-800 hover:bg-gray-700 border border-gray-700 rounded-lg flex items-center space-x-2 transition-colors relative"
+            className="px-4 py-2 bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:bg-gray-700 border border-gray-700 rounded-lg flex items-center space-x-2 transition-colors relative"
           >
             <Filter className="w-4 h-4 text-gray-400" />
             <span>Filters</span>
@@ -533,7 +533,7 @@ export const IngredientList = () => {
           {selectedCategories.map(category => (
             <div 
               key={category} 
-              className="px-3 py-1 bg-gray-700 rounded-full flex items-center text-sm"
+              className="px-3 py-1 bg-gray-200 dark:bg-gray-700 rounded-full flex items-center text-sm"
             >
               {category}
               <button 
@@ -554,10 +554,10 @@ export const IngredientList = () => {
       )}
 
       {/* Table */}
-      <div className="bg-gray-800/50 border border-gray-700 rounded-xl overflow-hidden">
+      <div className="bg-white/50 dark:bg-gray-800/50 border border-gray-700 rounded-xl overflow-hidden">
         <div className="overflow-x-auto">
           <table className="min-w-full divide-y divide-gray-700">
-            <thead className="bg-gray-800">
+            <thead className="bg-gray-100 dark:bg-gray-800">
               <tr>
                 <TableHeader
                   columnKey="name"
@@ -619,7 +619,7 @@ export const IngredientList = () => {
       {/* Add Ingredient Modal */}
       {showForm && (
         <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4">
-          <div className="bg-gray-800 border border-gray-700 rounded-xl w-full max-w-2xl max-h-[90vh] overflow-y-auto">
+          <div className="bg-gray-100 dark:bg-gray-800 border border-gray-700 rounded-xl w-full max-w-2xl max-h-[90vh] overflow-y-auto">
             <div className="p-6">
               <div className="flex justify-between items-center mb-4">
                 <h3 className="text-lg font-medium">Add New Ingredient</h3>
@@ -636,7 +636,7 @@ export const IngredientList = () => {
                   <button
                     type="button"
                     onClick={() => setShowForm(false)}
-                    className="px-4 py-2 border border-gray-600 rounded-lg hover:bg-gray-700 transition-colors"
+                    className="px-4 py-2 border border-gray-600 rounded-lg hover:bg-gray-200 dark:bg-gray-700 transition-colors"
                   >
                     Cancel
                   </button>

--- a/src/components/admin/Settings.tsx
+++ b/src/components/admin/Settings.tsx
@@ -45,7 +45,7 @@ export const Settings = () => {
   };
 
   return (
-    <div className="bg-gray-900/80 border border-gray-700 rounded-xl p-6 backdrop-blur-lg">
+    <div className="bg-white/80 dark:bg-gray-900/80 border border-gray-700 rounded-xl p-6 backdrop-blur-lg">
       {/* Header */}
       <div className="flex items-center space-x-3 mb-8">
         <SettingsIcon className="w-6 h-6 text-indigo-400" />
@@ -56,7 +56,7 @@ export const Settings = () => {
 
       <div className="space-y-8">
         {/* Units & Measurements */}
-        <div className="bg-gray-800/50 border border-gray-700 rounded-xl p-6">
+        <div className="bg-white/50 dark:bg-gray-800/50 border border-gray-700 rounded-xl p-6">
           <h3 className="text-lg font-medium mb-4 flex items-center space-x-2">
             <Lock className="w-5 h-5 text-indigo-400" />
             <span>System Preferences</span>
@@ -67,7 +67,7 @@ export const Settings = () => {
               <select 
                 value={units.weight}
                 onChange={(e) => setUnits({...units, weight: e.target.value})}
-                className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500 text-gray-200"
+                className="w-full px-3 py-2 bg-gray-200 dark:bg-gray-700 border border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500 text-gray-200"
               >
                 <option value="kg">Kilograms (kg)</option>
                 <option value="lb">Pounds (lb)</option>
@@ -79,7 +79,7 @@ export const Settings = () => {
               <select 
                 value={units.currency}
                 onChange={(e) => setUnits({...units, currency: e.target.value})}
-                className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500 text-gray-200"
+                className="w-full px-3 py-2 bg-gray-200 dark:bg-gray-700 border border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500 text-gray-200"
               >
                 <option value="USD">US Dollar ($)</option>
                 <option value="EUR">Euro (€)</option>
@@ -90,7 +90,7 @@ export const Settings = () => {
         </div>
 
         {/* Notifications */}
-        <div className="bg-gray-800/50 border border-gray-700 rounded-xl p-6">
+        <div className="bg-white/50 dark:bg-gray-800/50 border border-gray-700 rounded-xl p-6">
           <h3 className="text-lg font-medium mb-4 flex items-center space-x-2">
             <Bell className="w-5 h-5 text-indigo-400" />
             <span>Notification Preferences</span>
@@ -107,7 +107,7 @@ export const Settings = () => {
                   id={item.id}
                   checked={item.checked}
                   onChange={(e) => setNotifications({...notifications, [item.id]: e.target.checked})}
-                  className="h-4 w-4 bg-gray-700 border-gray-600 rounded focus:ring-indigo-500/50 focus:ring-offset-gray-800 text-indigo-500"
+                  className="h-4 w-4 bg-gray-200 dark:bg-gray-700 border-gray-600 rounded focus:ring-indigo-500/50 focus:ring-offset-gray-800 text-indigo-500"
                 />
                 <label htmlFor={item.id} className="ml-3 text-sm text-gray-300">
                   {item.label}
@@ -118,7 +118,7 @@ export const Settings = () => {
         </div>
 
         {/* User Management */}
-        <div className="bg-gray-800/50 border border-gray-700 rounded-xl p-6">
+        <div className="bg-white/50 dark:bg-gray-800/50 border border-gray-700 rounded-xl p-6">
           <div className="flex justify-between items-center mb-4">
             <h3 className="text-lg font-medium flex items-center space-x-2">
               <User className="w-5 h-5 text-indigo-400" />
@@ -145,7 +145,7 @@ export const Settings = () => {
               </thead>
               <tbody className="divide-y divide-gray-700">
                 {users.map((user) => (
-                  <tr key={user.id} className="hover:bg-gray-700/50 transition-colors">
+                  <tr key={user.id} className="hover:bg-gray-200/50 dark:bg-gray-700/50 transition-colors">
                     <td className="px-4 py-4">
                       <div className="flex items-center">
                         <div className="flex-shrink-0 h-10 w-10 rounded-full bg-indigo-500/20 flex items-center justify-center">
@@ -161,7 +161,7 @@ export const Settings = () => {
                       <span className={`px-2 py-1 rounded-full text-xs ${
                         user.role === 'Administrator' ? 'bg-purple-900/30 text-purple-400' :
                         user.role === 'Operator' ? 'bg-blue-900/30 text-blue-400' :
-                        'bg-gray-700 text-gray-300'
+                        'bg-gray-200 dark:bg-gray-700 text-gray-300'
                       }`}>
                         {user.role}
                       </span>
@@ -189,7 +189,7 @@ export const Settings = () => {
 
         {/* Save Settings */}
         <div className="pt-4 border-t border-gray-700 flex justify-end">
-          <button className="px-4 py-2 border border-gray-600 rounded-lg hover:bg-gray-700 mr-3 transition-colors">
+          <button className="px-4 py-2 border border-gray-600 rounded-lg hover:bg-gray-200 dark:bg-gray-700 mr-3 transition-colors">
             Cancel
           </button>
           <button className="px-4 py-2 bg-indigo-600 hover:bg-indigo-500 text-white rounded-lg flex items-center space-x-1 transition-colors">
@@ -202,7 +202,7 @@ export const Settings = () => {
       {/* Add User Modal */}
       {showUserForm && (
         <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4">
-          <div className="bg-gray-800 border border-gray-700 rounded-xl w-full max-w-md">
+          <div className="bg-gray-100 dark:bg-gray-800 border border-gray-700 rounded-xl w-full max-w-md">
             <div className="p-6">
               <div className="flex justify-between items-center mb-4">
                 <h3 className="text-lg font-medium">Add New User</h3>
@@ -220,7 +220,7 @@ export const Settings = () => {
                     type="text" 
                     value={newUser.name}
                     onChange={(e) => setNewUser({...newUser, name: e.target.value})}
-                    className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500 text-gray-200"
+                    className="w-full px-3 py-2 bg-gray-200 dark:bg-gray-700 border border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500 text-gray-200"
                   />
                 </div>
                 <div>
@@ -229,7 +229,7 @@ export const Settings = () => {
                     type="email" 
                     value={newUser.email}
                     onChange={(e) => setNewUser({...newUser, email: e.target.value})}
-                    className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500 text-gray-200"
+                    className="w-full px-3 py-2 bg-gray-200 dark:bg-gray-700 border border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500 text-gray-200"
                   />
                 </div>
                 <div>
@@ -237,7 +237,7 @@ export const Settings = () => {
                   <select 
                     value={newUser.role}
                     onChange={(e) => setNewUser({...newUser, role: e.target.value as User['role']})}
-                    className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500 text-gray-200"
+                    className="w-full px-3 py-2 bg-gray-200 dark:bg-gray-700 border border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500 text-gray-200"
                   >
                     <option value="Administrator">Administrator</option>
                     <option value="Operator">Operator</option>
@@ -248,7 +248,7 @@ export const Settings = () => {
                   <button 
                     type="button" 
                     onClick={() => setShowUserForm(false)}
-                    className="px-4 py-2 border border-gray-600 rounded-lg hover:bg-gray-700 transition-colors"
+                    className="px-4 py-2 border border-gray-600 rounded-lg hover:bg-gray-200 dark:bg-gray-700 transition-colors"
                   >
                     Cancel
                   </button>

--- a/src/components/admin/StockManagement.tsx
+++ b/src/components/admin/StockManagement.tsx
@@ -66,7 +66,7 @@ export const StockManagement = () => {
             <Plus className="w-4 h-4" />
             <span>Add Stock</span>
           </button>
-          <button className="px-4 py-2 border border-gray-600 hover:bg-gray-700 rounded-lg flex items-center space-x-2 transition-colors">
+          <button className="px-4 py-2 border border-gray-600 hover:bg-gray-200 dark:bg-gray-700 rounded-lg flex items-center space-x-2 transition-colors">
             <Download className="w-4 h-4" />
             <span>Export</span>
           </button>
@@ -74,10 +74,10 @@ export const StockManagement = () => {
       </div>
 
       {/* Inventory Table */}
-      <div className="bg-gray-800/50 border border-gray-700 rounded-xl overflow-hidden">
+      <div className="bg-white/50 dark:bg-gray-800/50 border border-gray-700 rounded-xl overflow-hidden">
         <div className="overflow-x-auto">
           <table className="min-w-full divide-y divide-gray-700">
-            <thead className="bg-gray-800">
+            <thead className="bg-gray-100 dark:bg-gray-800">
               <tr>
                 <th 
                   className="px-6 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider cursor-pointer"
@@ -131,7 +131,7 @@ export const StockManagement = () => {
                 <>
                   <tr 
                     key={item.id} 
-                    className="hover:bg-gray-700/50 transition-colors cursor-pointer"
+                    className="hover:bg-gray-200/50 dark:bg-gray-700/50 transition-colors cursor-pointer"
                     onClick={() => toggleExpand(item.id)}
                   >
                     <td className="px-6 py-4 whitespace-nowrap font-medium text-gray-200">
@@ -148,7 +148,7 @@ export const StockManagement = () => {
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-gray-400">
                       {item.current} {item.unit}
-                      <div className="w-full bg-gray-700 rounded-full h-1.5 mt-1">
+                      <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-1.5 mt-1">
                         <div 
                           className="h-1.5 rounded-full" 
                           style={{ 
@@ -178,7 +178,7 @@ export const StockManagement = () => {
                     </td>
                   </tr>
                   {expandedItem === item.id && (
-                    <tr className="bg-gray-800/70">
+                    <tr className="bg-white/70 dark:bg-gray-800/70">
                       <td colSpan={5} className="px-6 py-4">
                         <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
                           <div>
@@ -221,7 +221,7 @@ export const StockManagement = () => {
                               <button className="px-3 py-1.5 bg-indigo-600 hover:bg-indigo-500 text-white rounded-lg text-sm transition-colors">
                                 Order More
                               </button>
-                              <button className="px-3 py-1.5 border border-gray-600 hover:bg-gray-700 rounded-lg text-sm transition-colors">
+                              <button className="px-3 py-1.5 border border-gray-600 hover:bg-gray-200 dark:bg-gray-700 rounded-lg text-sm transition-colors">
                                 View History
                               </button>
                             </div>
@@ -238,9 +238,9 @@ export const StockManagement = () => {
       </div>
 
       {/* Stock Movement Chart */}
-      <div className="bg-gray-800/50 border border-gray-700 rounded-xl p-6">
+      <div className="bg-white/50 dark:bg-gray-800/50 border border-gray-700 rounded-xl p-6">
         <h3 className="text-lg font-medium mb-4">Stock Movement Analytics</h3>
-        <div className="h-80 bg-gray-700/50 rounded-lg flex items-center justify-center">
+        <div className="h-80 bg-gray-200/50 dark:bg-gray-700/50 rounded-lg flex items-center justify-center">
           <div className="text-center">
             <div className="w-16 h-16 bg-indigo-500/20 rounded-full flex items-center justify-center mx-auto mb-4">
               <ArrowUpDown className="w-8 h-8 text-indigo-400" />
@@ -254,7 +254,7 @@ export const StockManagement = () => {
       {/* Add Stock Modal */}
       {showStockForm && (
         <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4">
-          <div className="bg-gray-800 border border-gray-700 rounded-xl w-full max-w-md">
+          <div className="bg-gray-100 dark:bg-gray-800 border border-gray-700 rounded-xl w-full max-w-md">
             <div className="p-6">
               <div className="flex justify-between items-center mb-4">
                 <h3 className="text-lg font-medium">Add Stock Inventory</h3>
@@ -270,7 +270,7 @@ export const StockManagement = () => {
                   <label className="block text-sm text-gray-400 mb-2">Ingredient Name</label>
                   <input 
                     type="text" 
-                    className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500 text-gray-200"
+                    className="w-full px-3 py-2 bg-gray-200 dark:bg-gray-700 border border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500 text-gray-200"
                   />
                 </div>
                 <div className="grid grid-cols-2 gap-4">
@@ -278,20 +278,20 @@ export const StockManagement = () => {
                     <label className="block text-sm text-gray-400 mb-2">Current Stock</label>
                     <input 
                       type="number" 
-                      className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500 text-gray-200"
+                      className="w-full px-3 py-2 bg-gray-200 dark:bg-gray-700 border border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500 text-gray-200"
                     />
                   </div>
                   <div>
                     <label className="block text-sm text-gray-400 mb-2">Minimum Required</label>
                     <input 
                       type="number" 
-                      className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500 text-gray-200"
+                      className="w-full px-3 py-2 bg-gray-200 dark:bg-gray-700 border border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500 text-gray-200"
                     />
                   </div>
                 </div>
                 <div>
                   <label className="block text-sm text-gray-400 mb-2">Unit</label>
-                  <select className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500 text-gray-200">
+                  <select className="w-full px-3 py-2 bg-gray-200 dark:bg-gray-700 border border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500 text-gray-200">
                     <option>kg</option>
                     <option>lb</option>
                     <option>g</option>
@@ -302,7 +302,7 @@ export const StockManagement = () => {
                   <button 
                     type="button" 
                     onClick={() => setShowStockForm(false)}
-                    className="px-4 py-2 border border-gray-600 rounded-lg hover:bg-gray-700 transition-colors"
+                    className="px-4 py-2 border border-gray-600 rounded-lg hover:bg-gray-200 dark:bg-gray-700 transition-colors"
                   >
                     Cancel
                   </button>

--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -19,7 +19,7 @@ export default function Footer() {
   const currentYear = new Date().getFullYear();
 
   return (
-    <footer className="bg-gray-900 text-white">
+    <footer className="bg-gray-100 dark:bg-gray-900 text-gray-700 dark:text-white">
       {/* Main Footer Content */}
       <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-16">
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-10">
@@ -29,16 +29,16 @@ export default function Footer() {
               <FaWheatAwn className="text-green-500 text-3xl mr-3" />
               <span className="text-2xl font-bold">FeedSport</span>
             </div>
-            <p className="text-gray-400 mb-6">
+            <p className="text-gray-600 dark:text-gray-400 mb-6">
               Pioneering animal nutrition solutions through science and innovation. 
               Empowering farmers with premium feed ingredients since 2010.
             </p>
             
             <div className="mb-6">
-              <h4 className="text-sm font-semibold text-gray-300 mb-3">CERTIFICATIONS</h4>
+              <h4 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">CERTIFICATIONS</h4>
               <div className="flex items-center gap-3">
                 <FaShieldHalved className="text-green-500 text-xl" />
-                <span className="text-sm text-gray-400">ISO 9001:2015 Certified</span>
+                <span className="text-sm text-gray-500 dark:text-gray-400">ISO 9001:2015 Certified</span>
               </div>
             </div>
 
@@ -54,7 +54,7 @@ export default function Footer() {
                   href={social.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-gray-400 hover:text-green-500 transition-colors duration-300"
+                  className="text-gray-500 dark:text-gray-400 hover:text-green-600 dark:hover:text-green-500 transition-colors duration-300"
                   aria-label={`Follow us on ${social.icon.name.replace('Fa', '')}`}
                 >
                   <social.icon className="text-xl" />
@@ -65,7 +65,7 @@ export default function Footer() {
 
           {/* Quick Links */}
           <div>
-            <h4 className="text-lg font-bold mb-6 text-white">Quick Links</h4>
+            <h4 className="text-lg font-bold mb-6 text-gray-900 dark:text-white">Quick Links</h4>
             <ul className="space-y-3">
               {[
                 { name: "Home", href: "/" },
@@ -77,7 +77,7 @@ export default function Footer() {
                 <li key={link.name}>
                   <Link
                     href={link.href}
-                    className="text-gray-400 hover:text-green-500 transition-colors duration-300"
+                    className="text-gray-500 dark:text-gray-400 hover:text-green-600 dark:hover:text-green-500 transition-colors duration-300"
                   >
                     {link.name}
                   </Link>
@@ -88,7 +88,7 @@ export default function Footer() {
 
           {/* Products */}
           <div>
-            <h4 className="text-lg font-bold mb-6 text-white">Products</h4>
+            <h4 className="text-lg font-bold mb-6 text-gray-900 dark:text-white">Products</h4>
             <ul className="space-y-3">
               {[
                 { name: "Protein Sources", href: "/products/protein" },
@@ -100,7 +100,7 @@ export default function Footer() {
                 <li key={product.name}>
                   <Link
                     href={product.href}
-                    className="text-gray-400 hover:text-green-500 transition-colors duration-300"
+                    className="text-gray-500 dark:text-gray-400 hover:text-green-600 dark:hover:text-green-500 transition-colors duration-300"
                   >
                     {product.name}
                   </Link>
@@ -111,18 +111,18 @@ export default function Footer() {
 
           {/* Contact Info */}
           <div>
-            <h4 className="text-lg font-bold mb-6 text-white">Contact Us</h4>
+            <h4 className="text-lg font-bold mb-6 text-gray-900 dark:text-white">Contact Us</h4>
             <ul className="space-y-4">
               <li className="flex items-start">
                 <FaMapMarkerAlt className="text-green-500 mt-1 mr-3 flex-shrink-0" />
-                <span className="text-gray-400">2 William Pollet, Borrowdale, Harare, Zimbabwe</span>
+                <span className="text-gray-500 dark:text-gray-400">2 William Pollet, Borrowdale, Harare, Zimbabwe</span>
               </li>
               <li className="flex items-center">
                 <FaPhoneAlt className="text-green-500 mr-3 flex-shrink-0" />
                 <div>
                   <a 
                     href="tel:+263774684534" 
-                    className="text-gray-400 hover:text-green-500 transition-colors duration-300 block"
+                    className="text-gray-500 dark:text-gray-400 hover:text-green-600 dark:hover:text-green-500 transition-colors duration-300 block"
                   >
                     +263 77 468 4534
                   </a>
@@ -140,14 +140,14 @@ export default function Footer() {
                 <FaEnvelope className="text-green-500 mr-3 flex-shrink-0" />
                 <a 
                   href="mailto:sales@feedsport.com" 
-                  className="text-gray-400 hover:text-green-500 transition-colors duration-300"
+                  className="text-gray-500 dark:text-gray-400 hover:text-green-600 dark:hover:text-green-500 transition-colors duration-300"
                 >
                   sales@feedsport.com
                 </a>
               </li>
               <li className="flex items-center">
                 <FaRegClock className="text-green-500 mr-3 flex-shrink-0" />
-                <span className="text-gray-400">Mon-Fri: 8AM - 5PM</span>
+                <span className="text-gray-500 dark:text-gray-400">Mon-Fri: 8AM - 5PM</span>
               </li>
             </ul>
           </div>
@@ -155,34 +155,34 @@ export default function Footer() {
       </div>
 
       {/* Footer Bottom */}
-      <div className="border-t border-gray-800 py-6">
+      <div className="border-t border-gray-300 dark:border-gray-800 py-6">
         <div className="container mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex flex-col md:flex-row justify-between items-center">
-            <p className="text-gray-500 text-sm mb-4 md:mb-0">
+            <p className="text-gray-600 dark:text-gray-500 text-sm mb-4 md:mb-0">
               &copy; {currentYear} FeedSport International. All rights reserved.
             </p>
             <div className="flex flex-wrap justify-center gap-4 md:gap-6">
               <Link
                 href="/privacy"
-                className="text-gray-500 hover:text-green-500 text-sm transition-colors duration-300"
+                className="text-gray-600 dark:text-gray-500 hover:text-green-600 dark:hover:text-green-500 text-sm transition-colors duration-300"
               >
                 Privacy Policy
               </Link>
               <Link
                 href="/terms"
-                className="text-gray-500 hover:text-green-500 text-sm transition-colors duration-300"
+                className="text-gray-600 dark:text-gray-500 hover:text-green-600 dark:hover:text-green-500 text-sm transition-colors duration-300"
               >
                 Terms of Service
               </Link>
               <Link
                 href="/sitemap"
-                className="text-gray-500 hover:text-green-500 text-sm transition-colors duration-300"
+                className="text-gray-600 dark:text-gray-500 hover:text-green-600 dark:hover:text-green-500 text-sm transition-colors duration-300"
               >
                 Sitemap
               </Link>
               <Link
                 href="/careers"
-                className="text-gray-500 hover:text-green-500 text-sm transition-colors duration-300"
+                className="text-gray-600 dark:text-gray-500 hover:text-green-600 dark:hover:text-green-500 text-sm transition-colors duration-300"
               >
                 Careers
               </Link>

--- a/src/components/common/NavBar.tsx
+++ b/src/components/common/NavBar.tsx
@@ -56,10 +56,11 @@ export default function NavBar() {
   return (
     <nav
       ref={navRef}
-      className={`fixed top-0 w-full z-50 transition-all duration-300 ${scrolled
-          ? 'bg-green-950 backdrop-blur-sm border-b border-gray-800'
+      className={`fixed top-0 w-full z-50 transition-all duration-300 ${
+        scrolled
+          ? 'bg-green-950 dark:bg-green-900 backdrop-blur-sm border-b border-gray-800 dark:border-gray-700'
           : 'bg-transparent'
-        }`}
+      }`}
     >
       <div className="mx-auto px-4 sm:px-6 flex items-center justify-between h-16">
         {/* Logo */}
@@ -113,7 +114,7 @@ export default function NavBar() {
           <div ref={searchRef} className="relative">
             <motion.button
               onClick={() => setSearchOpen(o => !o)}
-              className="p-2 rounded-full hover:bg-gray-800 transition-colors"
+              className="p-2 rounded-full hover:bg-gray-200 dark:hover:bg-gray-800 transition-colors"
               aria-label="Search"
               whileTap={{ scale: 0.9 }}
             >
@@ -131,7 +132,7 @@ export default function NavBar() {
                   animate={{ opacity: 1, y: 0 }}
                   exit={{ opacity: 0, y: -10 }}
                   transition={{ type: 'spring', stiffness: 300 }}
-                  className="absolute right-0 mt-2 w-72 bg-gray-800 rounded-lg shadow-xl overflow-hidden border border-gray-700"
+                  className="absolute right-0 mt-2 w-72 bg-gray-100 dark:bg-gray-800 rounded-lg shadow-xl overflow-hidden border border-gray-200 dark:border-gray-700"
                 >
                   <div className="relative">
                     <input
@@ -140,11 +141,11 @@ export default function NavBar() {
                       value={query}
                       onChange={e => setQuery(e.target.value)}
                       placeholder="Search products, resources..."
-                      className="w-full px-4 py-3 pr-10 text-gray-200 bg-gray-700 focus:outline-none placeholder-gray-400"
+                      className="w-full px-4 py-3 pr-10 text-gray-900 dark:text-gray-200 bg-gray-50 dark:bg-gray-700 focus:outline-none placeholder-gray-400"
                     />
                     <button
                       type="submit"
-                      className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-400 hover:text-green-400"
+                      className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-400 hover:text-green-500"
                     >
                       <FaSearch />
                     </button>
@@ -162,7 +163,7 @@ export default function NavBar() {
             <a
               href="https://wa.me/263774684534"
               target="_blank"
-              className="relative p-3 bg-gray-800 rounded-full hover:bg-gray-700 transition-colors group"
+              className="relative p-3 bg-gray-200 dark:bg-gray-800 rounded-full hover:bg-gray-300 dark:hover:bg-gray-700 transition-colors group"
               aria-label="Contact"
             >
               <FaPhoneAlt className="text-green-400 text-xl group-hover:rotate-12 transition-transform" />
@@ -175,10 +176,10 @@ export default function NavBar() {
               </motion.span>
             </a>
             <div className="hidden lg:block text-left">
-              <p className="text-xs text-gray-400">Expert Support</p>
+              <p className="text-xs text-gray-500 dark:text-gray-400">Expert Support</p>
               <Link
                 href="tel:+263774684534"
-                className="font-medium text-gray-300 hover:text-green-400 text-sm transition-colors"
+                className="font-medium text-gray-700 dark:text-gray-300 hover:text-green-600 dark:hover:text-green-400 text-sm transition-colors"
               >
                 +263 77 468 4534
               </Link>
@@ -202,7 +203,7 @@ export default function NavBar() {
           {/* Mobile toggle */}
           <motion.button
             onClick={() => setMobileOpen(o => !o)}
-            className="lg:hidden p-2 rounded-lg hover:bg-gray-800 transition-colors"
+            className="lg:hidden p-2 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-800 transition-colors"
             aria-label="Menu"
             whileTap={{ scale: 0.9 }}
           >
@@ -223,7 +224,7 @@ export default function NavBar() {
             animate={{ height: 'auto', opacity: 1 }}
             exit={{ height: 0, opacity: 0 }}
             transition={{ type: 'spring', bounce: 0.1 }}
-            className="lg:hidden bg-gray-900 overflow-hidden shadow-inner"
+            className="lg:hidden bg-gray-100 dark:bg-gray-900 overflow-hidden shadow-inner"
           >
             <div className="px-4 py-3 space-y-2">
               {links.map(link => (
@@ -231,8 +232,8 @@ export default function NavBar() {
                   key={link.href}
                   href={link.href}
                   className={`block px-4 py-3 rounded-lg font-medium transition-colors ${isActive(link.href)
-                      ? 'bg-gray-800 text-green-400'
-                      : 'text-gray-300 hover:bg-gray-800'
+                      ? 'bg-gray-200 dark:bg-gray-800 text-green-600 dark:text-green-400'
+                      : 'text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-800'
                     }`}
                   onClick={() => setMobileOpen(false)}
                 >

--- a/src/components/common/TopBar.tsx
+++ b/src/components/common/TopBar.tsx
@@ -5,18 +5,18 @@ import { FaEnvelope, FaFacebookF, FaGlobeAmericas, FaInstagram, FaMapMarkerAlt, 
 
 export default function TopBar() {
   return (
-    <div className="bg-gray-100 py-2 hidden lg:block">
+    <div className="bg-gray-100 dark:bg-gray-900 py-2 hidden lg:block text-gray-700 dark:text-gray-200">
       <div className="container mx-auto px-4">
         <div className="flex justify-between items-center">
           <div className="flex space-x-4">
             <div className="border-r border-green-600 pr-3">
-              <Link href="/locations" className="flex text-gray-600 text-sm hover:text-green-600">
+              <Link href="/locations" className="flex text-gray-600 dark:text-gray-300 text-sm hover:text-green-600">
                 <FaMapMarkerAlt className="text-green-600 mr-2" />
                 Find A Distributor
               </Link>
             </div>
             <div className="pl-3">
-              <Link href="mailto:sales@feedsport.com" className="flex text-gray-600 text-sm hover:text-green-600">
+              <Link href="mailto:sales@feedsport.com" className="flex text-gray-600 dark:text-gray-300 text-sm hover:text-green-600">
                 <FaEnvelope className="text-green-600 mr-2" />
                 sales@feedsport.co.zw
               </Link>
@@ -35,7 +35,7 @@ export default function TopBar() {
               </Link>
             </div>
             <div className="dropdown ml-3">
-              <button className="flex items-center text-gray-700 text-sm">
+              <button className="flex items-center text-gray-700 dark:text-gray-300 text-sm">
                 <FaGlobeAmericas className="text-green-600 mr-2" /> English
               </button>
             </div>

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -12,7 +12,7 @@ interface ThemeContextType {
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined)
 
 export const ThemeProvider = ({ children }: { children: ReactNode }) => {
-  const [theme, setTheme] = useState<Theme>('dark')
+  const [theme, setTheme] = useState<Theme>('light')
 
   // load saved theme
   useEffect(() => {

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react'
+
+type Theme = 'light' | 'dark'
+
+interface ThemeContextType {
+  theme: Theme
+  toggleTheme: () => void
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined)
+
+export const ThemeProvider = ({ children }: { children: ReactNode }) => {
+  const [theme, setTheme] = useState<Theme>('dark')
+
+  // load saved theme
+  useEffect(() => {
+    const stored = typeof window !== 'undefined' ? localStorage.getItem('theme') : null
+    if (stored === 'light' || stored === 'dark') {
+      setTheme(stored)
+    }
+  }, [])
+
+  // apply theme class to html element
+  useEffect(() => {
+    if (typeof document !== 'undefined') {
+      const root = document.documentElement
+      root.classList.toggle('dark', theme === 'dark')
+      localStorage.setItem('theme', theme)
+    }
+  }, [theme])
+
+  const toggleTheme = () => {
+    setTheme(prev => (prev === 'light' ? 'dark' : 'light'))
+  }
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}
+
+export const useTheme = (): ThemeContextType => {
+  const context = useContext(ThemeContext)
+  if (!context) throw new Error('useTheme must be used within ThemeProvider')
+  return context
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  darkMode: 'class',
   theme: {
     extend: {
       fontFamily: {


### PR DESCRIPTION
## Summary
- introduce `ThemeContext` for light/dark theme switching
- enable Tailwind dark mode class
- wrap layout in `ThemeProvider`
- add theme toggle in admin sidebar and adjust styles for both themes

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68602c80e0388321a323d64b5ce3c1d1