### PR TITLE
Remove Analyze button

### DIFF
--- a/src/components/admin/FeedRations/FeedRatios.tsx
+++ b/src/components/admin/FeedRations/FeedRatios.tsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { getIngredients } from "@/data/ingredients";
 import { getNutrients } from "@/data/nutrients";
-import { IngredientAnalyser } from "@/services/coordinate-decent";
 import { RatioOptimizer } from "@/services/simplex";
 import { Formulation, Ingredient, IngredientSuggestion, RatioIngredient, TargetNutrient } from "@/types";
 import { Animal, AnimalNutrientRequirement, AnimalProgram, AnimalProgramStage } from "@/types/animals";
@@ -29,7 +28,6 @@ export const FeedRatios = () => {
   const [showIngredientModal, setShowIngredientModal] = useState(false);
   const [showTargetModal, setShowTargetModal] = useState(false);
   const [optimizing, setOptimizing] = useState(false);
-  const [analysing, setAnalysing] = useState(false);
   const [suggestedIngredients, setSuggestedIngredients] = useState<IngredientSuggestion[]>([]);
   const [visibleColumns, setVisibleColumns] = useState<string[]>([]);
   const [showColumnConfig, setShowColumnConfig] = useState(false);
@@ -165,39 +163,6 @@ export const FeedRatios = () => {
     setSavedFormulations(prev => prev.filter(f => f.id !== id));
   };
 
-  // Update analyzeRatios to always update ratios
-  const analyzeRatios = useCallback(async () => {
-    if (ingredients.length === 0) return;
-    setSuggestedIngredients([]);
-    setAnalysing(true);
-
-    try {
-      const result = IngredientAnalyser.analyze(ingredients, targets);
-      // Always update ratios if we have updated ingredients
-      if (result.updatedIngredients) {
-        // Scale ratios to match original total
-        const originalTotal = ingredients.reduce((sum, i) => sum + i.ratio, 0);
-        const updatedTotal = result.updatedIngredients.reduce((sum, i) => sum + i.ratio, 0);
-        const scalingFactor = originalTotal / updatedTotal;
-
-        const scaledIngredients = result.updatedIngredients.map(i => ({
-          ...i,
-          ratio: i.ratio * scalingFactor
-        }));
-
-        setIngredients(scaledIngredients);
-      }
-
-      // Always show suggestions if available
-      if (result.suggestions) {
-        setSuggestedIngredients(result.suggestions);
-      }
-    } finally {
-      setAnalysing(false);
-    }
-  }, [ingredients, targets]);
-
-
   const optimizeRatios = useCallback(async () => {
     if (ingredients.length === 0 || targets.length === 0) return;
     setSuggestedIngredients([]);
@@ -266,9 +231,7 @@ export const FeedRatios = () => {
       <FeedRatiosHeader
         onShowHistory={() => setShowHistory(true)}
         onOptimize={optimizeRatios}
-        onAnalyze={analyzeRatios}
         optimizing={optimizing}
-        analysing={analysing}
       />
 
       <div className="flex flex-col lg:flex-row gap-6 justify-between">

--- a/src/components/admin/FeedRations/FeedRatiosHeader.tsx
+++ b/src/components/admin/FeedRations/FeedRatiosHeader.tsx
@@ -1,19 +1,15 @@
-import { Calculator, History, Wand, ZoomIn } from "lucide-react";
+import { Calculator, History, Wand } from "lucide-react";
 
 interface FeedRatiosHeaderProps {
   onShowHistory: () => void;
   onOptimize: () => void;
-  onAnalyze: () => void;
   optimizing: boolean;
-  analysing: boolean;
 }
 
 export const FeedRatiosHeader = ({
   onShowHistory,
   onOptimize,
-  onAnalyze,
-  optimizing,
-  analysing
+  optimizing
 }: FeedRatiosHeaderProps) => (
   <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
     <div className="flex items-center space-x-3">
@@ -39,13 +35,6 @@ export const FeedRatiosHeader = ({
         <span>{optimizing ? 'Optimizing...' : 'Optimize'}</span>
       </button>
       
-      <button
-        onClick={onAnalyze}
-        className="px-4 py-2 bg-purple-600 hover:bg-magenta-500 text-white rounded-lg flex items-center space-x-2"
-      >
-        <ZoomIn className="w-4 h-4" />
-        <span>{analysing ? 'Analyzing...' : 'Analyze'}</span>
-      </button>
     </div>
   </div>
 );


### PR DESCRIPTION
## Summary
- remove Analyze CTA and related logic from admin ratios page

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686094d2f1d483219ea7e9edc1491e32