### PR TITLE
Remove unused React imports

### DIFF
--- a/src/app/(admin)/layout.tsx
+++ b/src/app/(admin)/layout.tsx
@@ -1,11 +1,12 @@
 
 import "@/app/globals.css";
 import { AnimalProvider } from "@/context/AnimalContext";
+import type { ReactNode } from 'react';
 
 export default function AdminLayout({
   children,
 }: Readonly<{
-  children: React.ReactNode;
+  children: ReactNode;
 }>) {
   return (
       <AnimalProvider>

--- a/src/app/(blog)/blog/[slug]/page.tsx
+++ b/src/app/(blog)/blog/[slug]/page.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 export async function generateStaticParams() {
   return [

--- a/src/app/(blog)/layout.tsx
+++ b/src/app/(blog)/layout.tsx
@@ -2,11 +2,12 @@
 import "@/app/globals.css";
 import Footer from "@/components/common/Footer";
 import NavBar from "@/components/common/NavBar";
+import type { ReactNode } from 'react';
 
 export default function BlogLayout({
   children,
 }: Readonly<{
-  children: React.ReactNode;
+  children: ReactNode;
 }>) {
   return (
     <>

--- a/src/app/(invoice)/brochure/page.tsx
+++ b/src/app/(invoice)/brochure/page.tsx
@@ -2,7 +2,7 @@
 import { Badge, Beef, Bird, Droplets, Egg, Leaf, Mail, MapPin, Phone, ShieldCheck, Sun, TestTube2, Truck, Wheat } from 'lucide-react';
 import Head from 'next/head';
 import Image from 'next/image';
-import React from 'react';
+import type { FC, ReactNode, SyntheticEvent } from 'react';
 
 interface Product {
   id: number;
@@ -16,7 +16,7 @@ interface Product {
   priceUSD: string;
   moq: string;
   image: string;
-  icon?: React.ReactNode;
+  icon?: ReactNode;
 }
 
 const getProductImage = (imagePath: string, productName: string) => {
@@ -223,8 +223,8 @@ interface ProductImageProps {
   productName: string;
 }
 
-const ProductImage: React.FC<ProductImageProps> = ({ src, alt, productName }) => {
-  const handleError = (e: React.SyntheticEvent<HTMLImageElement, Event>) => {
+const ProductImage: FC<ProductImageProps> = ({ src, alt, productName }) => {
+  const handleError = (e: SyntheticEvent<HTMLImageElement, Event>) => {
     const target = e.target as HTMLImageElement;
     target.onerror = null;
     target.src = `https://placehold.co/100x100/F3F3F3/333333?text=${encodeURIComponent(productName.substring(0, 15))}`;
@@ -248,7 +248,7 @@ interface ProductDetailsProps {
   product: Product;
 }
 
-const ProductDetails: React.FC<ProductDetailsProps> = ({ product }) => (
+const ProductDetails: FC<ProductDetailsProps> = ({ product }) => (
   <div className="flex-grow flex flex-col">
     {/* Product Header */}
     <div className="flex px-4 pt-4 justify-between items-start">
@@ -330,17 +330,21 @@ const ProductDetails: React.FC<ProductDetailsProps> = ({ product }) => (
   </div>
 );
 
-const ProductCard: React.FC<{ product: Product }> = ({ product }) => (
+const ProductCard: FC<{ product: Product }> = ({ product }) => (
   <article className="bg-white border border-gray-200 rounded-sm overflow-hidden flex flex-col h-full shadow-sm hover:shadow-md transition-shadow print:break-inside-avoid">
     <ProductDetails product={product} />
   </article>
 );
 
-const Price = ({ children }: { children: React.ReactNode }) => <span className={`font-bold text-base text-green-700 sans-serif`}>{children}</span>;
+const Price = ({ children }: { children: ReactNode }) => (
+  <span className={`font-bold text-base text-green-700 sans-serif`}>{children}</span>
+);
 
-const ProductTitle = ({ children, className }: { children: React.ReactNode, className?: string }) => <h2 className={`sans-serif text-lg font-semibold text-gray-800 leading-tight ${className}`}>{children}</h2>;
+const ProductTitle = ({ children, className }: { children: ReactNode; className?: string }) => (
+  <h2 className={`sans-serif text-lg font-semibold text-gray-800 leading-tight ${className}`}>{children}</h2>
+);
 
-const CataloguePage: React.FC = () => {
+const CataloguePage: FC = () => {
   const currentYear = new Date().getFullYear();
 
   const contactItems = [

--- a/src/app/(invoice)/cv/page.tsx
+++ b/src/app/(invoice)/cv/page.tsx
@@ -1,7 +1,7 @@
 // app/page.tsx
 "use client";
 
-import React from 'react';
+import type { FC, ReactNode } from 'react';
 import { FaDownload, FaGithub, FaLinkedin, FaEnvelope, FaGlobe, FaPhone } from 'react-icons/fa';
 import { Merriweather, Orbitron, Inter } from 'next/font/google';
 
@@ -178,10 +178,10 @@ const cvData = {
 
 interface SectionProps {
   title: string;
-  children: React.ReactNode;
+  children: ReactNode;
 }
 
-const Section: React.FC<SectionProps> = ({ title, children }) => (
+const Section: FC<SectionProps> = ({ title, children }) => (
   <section className="mb-8">
     <div className="flex items-center mb-4 break-inside-avoid">
       <div className="bg-gradient-to-r from-cyan-500 to-teal-500 w-3 h-8 rounded-md mr-3" />

--- a/src/app/(invoice)/layout.tsx
+++ b/src/app/(invoice)/layout.tsx
@@ -1,10 +1,11 @@
 
 import "@/app/globals.css";
+import type { ReactNode } from 'react';
 
 export default function InvoiceLayout({
   children,
 }: Readonly<{
-  children: React.ReactNode;
+  children: ReactNode;
 }>) {
   return (
       <>

--- a/src/app/(invoice)/newsletter/page.tsx
+++ b/src/app/(invoice)/newsletter/page.tsx
@@ -2,7 +2,7 @@
 
 import { Check, X } from 'lucide-react';
 import { Merriweather, Orbitron } from 'next/font/google';
-import React from 'react';
+import type { ReactElement, ReactNode } from 'react';
 import { FaWhatsapp } from 'react-icons/fa6';
 import Image from 'next/image';
 
@@ -16,7 +16,7 @@ const major = Orbitron({
   subsets: ['latin'],
 })
 
-const PrintWatermark = ({ children }: { children: React.ReactNode }): React.ReactElement => (
+const PrintWatermark = ({ children }: { children: ReactNode }): ReactElement => (
   <div className='font-serif'>
     {children}
   </div>
@@ -26,13 +26,13 @@ const Heading = ({
   children,
   className,
 }: {
-  children: React.ReactNode;
+  children: ReactNode;
   className?: string;
-}): React.ReactElement => (
+}): ReactElement => (
   <h1 className={`${merri.className} ${className}`}>{children}</h1>
 )
 
-const NumberedItem = ({ children, className }: { children: React.ReactNode; className?: string }): React.ReactElement => {
+const NumberedItem = ({ children, className }: { children: ReactNode; className?: string }): ReactElement => {
   const classNames = "w-12 h-12 flex flex-none items-center justify-center bg-gradient-to-br from-green-100 to-green-50 border-2 border-green-200 text-2xl font-bold text-green-800 rounded-full shadow-lg shadow-green-100/50 hover:scale-105 transition-transform focus:outline-none focus:ring-2 focus:ring-green-300 print:bg-white print:border print:border-gray-300";
 
   return (

--- a/src/app/(invoice)/resume/page.tsx
+++ b/src/app/(invoice)/resume/page.tsx
@@ -1,7 +1,7 @@
 // app/page.tsx
 "use client";
 
-import React from 'react';
+import type { FC, ReactNode } from 'react';
 import { FaDownload, FaGithub, FaLinkedin, FaEnvelope, FaGlobe, FaPhone } from 'react-icons/fa';
 import { Merriweather, Orbitron, Inter } from 'next/font/google';
 
@@ -187,10 +187,10 @@ const cvData = {
 
 interface SectionProps {
   title: string;
-  children: React.ReactNode;
+  children: ReactNode;
 }
 
-const Section: React.FC<SectionProps> = ({ title, children }) => (
+const Section: FC<SectionProps> = ({ title, children }) => (
   <section className="mb-8">
     <div className="flex items-center mb-4 break-inside-avoid">
       <div className="bg-gradient-to-r from-cyan-500 to-teal-500 w-3 h-8 rounded-md mr-3" />

--- a/src/app/(main)/contact/page.tsx
+++ b/src/app/(main)/contact/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, type ChangeEvent, type FormEvent } from 'react';
 import { motion } from 'framer-motion';
 import { FiSend, FiUser, FiMail, FiMessageSquare } from 'react-icons/fi';
 import SecondaryHero from '@/components/common/SecondaryHero';
@@ -19,13 +19,13 @@ export default function ContactPage() {
   });
 
   const handleChange = (
-    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
   ): void => {
     const { id, value } = e.target;
     setFormData(prev => ({ ...prev, [id]: value }));
   };
 
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>): void => {
+  const handleSubmit = (e: FormEvent<HTMLFormElement>): void => {
     e.preventDefault();
     // Handle form submission
     console.log('Form submitted:', formData);

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -2,11 +2,12 @@
 import "@/app/globals.css";
 import Footer from "@/components/common/Footer";
 import NavBar from "@/components/common/NavBar";
+import type { ReactNode } from 'react';
 
 export default function MainLayout({
   children,
 }: Readonly<{
-  children: React.ReactNode;
+  children: ReactNode;
 }>) {
   return (
     <>

--- a/src/app/(main)/recipe/page.tsx
+++ b/src/app/(main)/recipe/page.tsx
@@ -3,7 +3,7 @@
 import SecondaryHero from '@/components/common/SecondaryHero'
 import { AnimatePresence, motion } from 'framer-motion'
 import Link from 'next/link'
-import { useState } from 'react'
+import { useState, type ReactNode } from 'react'
 import { FiBarChart2, FiDownload, FiInfo, FiShare2 } from 'react-icons/fi'
 import { GiChickenOven, GiWeight } from 'react-icons/gi'
 import { TbChartArcs, TbMeat } from 'react-icons/tb'
@@ -13,7 +13,7 @@ interface Nutrient {
   value: number
   unit: string
   idealRange: [number, number]
-  icon: React.ReactNode
+  icon: ReactNode
   description: string
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import { GoogleAnalytics } from "@next/third-parties/google";
 import { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import type { ReactNode } from 'react';
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -20,7 +21,7 @@ export const metadata: Metadata = {
 export default function RootLayout({
   children, // Will be either main or invoice layout + pages
 }: {
-  children: React.ReactNode
+  children: ReactNode
 }) {
   return (
     <html lang="en">

--- a/src/components/admin/FeedRations/ContributionChart.tsx
+++ b/src/components/admin/FeedRations/ContributionChart.tsx
@@ -1,5 +1,5 @@
 import { RatioIngredient, TargetNutrient } from '@/types';
-import React, { useMemo } from 'react';
+import { useMemo, type FC } from 'react';
 import {
   BarChart,
   Bar,
@@ -18,7 +18,7 @@ interface ContributionChartProps {
   targets: TargetNutrient[];
 }
 
-export const ContributionChart: React.FC<ContributionChartProps> = ({
+export const ContributionChart: FC<ContributionChartProps> = ({
   ingredients,
   computedValues,
   totalRatio,
@@ -114,7 +114,7 @@ export const ContributionChart: React.FC<ContributionChartProps> = ({
     payload: { value: string };
   }
 
-  const CustomYAxisTick: React.FC<AxisTickProps> = ({ x, y, payload }) => {
+  const CustomYAxisTick: FC<AxisTickProps> = ({ x, y, payload }) => {
     const lines = splitLabel(payload.value);
     return (
       <g transform={`translate(${x},${y})`}>
@@ -148,7 +148,7 @@ export const ContributionChart: React.FC<ContributionChartProps> = ({
     label?: string;
   }
 
-  const CustomTooltip: React.FC<CustomTooltipProps> = ({ active, payload, label }) => {
+  const CustomTooltip: FC<CustomTooltipProps> = ({ active, payload, label }) => {
     if (!active || !payload?.length || !payload[0]?.payload) return null;
 
     const rowData = payload[0].payload as Record<string, string | number>; // Access the full row data for the current nutrient

--- a/src/components/admin/FeedRations/IngredientSelectionModal.tsx
+++ b/src/components/admin/FeedRations/IngredientSelectionModal.tsx
@@ -1,6 +1,6 @@
 import { Ingredient, TargetNutrient } from "@/types";
 import { Search, X } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ChangeEvent } from "react";
 
 interface IngredientSelectionModalProps {
   isOpen: boolean;
@@ -38,7 +38,7 @@ export const IngredientSelectionModal = ({
     }
   }, [searchTerm, allIngredients, isOpen]);
 
-  const handleSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleSearch = (e: ChangeEvent<HTMLInputElement>) => {
     setSearchTerm(e.target.value);
   };
 

--- a/src/components/admin/FeedRations/TargetInputItem.tsx
+++ b/src/components/admin/FeedRations/TargetInputItem.tsx
@@ -1,7 +1,7 @@
 // TargetInputItem.tsx
 import { TargetNutrient } from "@/types";
 import { X } from "lucide-react";
-import { useState } from "react";
+import { useState, type ChangeEvent } from "react";
 
 export const TargetInputItem = ({
   target,
@@ -18,7 +18,10 @@ export const TargetInputItem = ({
   const DEFAULT_UNDER_PENALTY = 1000;
   const DEFAULT_OVER_PENALTY = 1000;
 
-  const handleChange = (field: 'max' | 'target' | 'underPenaltyFactor' | 'overPenaltyFactor', e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleChange = (
+    field: 'max' | 'target' | 'underPenaltyFactor' | 'overPenaltyFactor',
+    e: ChangeEvent<HTMLInputElement>
+  ) => {
     const value = Math.max(0, Number(e.target.value));
     onUpdate(field, value);
   };

--- a/src/components/blog/NewsletterSignup.tsx
+++ b/src/components/blog/NewsletterSignup.tsx
@@ -1,7 +1,7 @@
 // components/NewsletterSignup.tsx
 'use client';
 
-import { useState } from 'react';
+import { useState, type FormEvent } from 'react';
 import { FiMail } from 'react-icons/fi';
 
 export default function NewsletterSignup() {
@@ -9,7 +9,7 @@ export default function NewsletterSignup() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isSuccess, setIsSuccess] = useState(false);
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     setIsSubmitting(true);
     

--- a/src/components/common/AnimalSelector.tsx
+++ b/src/components/common/AnimalSelector.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect, type FC, type ChangeEvent } from 'react';
 import { useAnimal } from '@/context/AnimalContext';
 import { Animal, AnimalProgram, AnimalProgramStage } from '@/types/animals';
 
@@ -11,25 +11,25 @@ interface AnimalSelectorProps {
   ) => void;
 }
 
-const AnimalSelector: React.FC<AnimalSelectorProps> = ({ onSelectionChange }) => {
+const AnimalSelector: FC<AnimalSelectorProps> = ({ onSelectionChange }) => {
   const { animals, selectedAnimal, setSelectedAnimal } = useAnimal();
   const [selectedProgram, setSelectedProgram] = useState<AnimalProgram | null>(null);
   const [selectedStage, setSelectedStage] = useState<AnimalProgramStage | null>(null);
 
-  const handleAnimalChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+  const handleAnimalChange = (e: ChangeEvent<HTMLSelectElement>) => {
     const animal = animals.find((a) => a.id === Number(e.target.value));
     setSelectedAnimal(animal ?? null);
     setSelectedProgram(null);
     setSelectedStage(null);
   };
 
-  const handleProgramChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+  const handleProgramChange = (e: ChangeEvent<HTMLSelectElement>) => {
     const program = selectedAnimal?.programs.find((p: AnimalProgram) => p.id === Number(e.target.value)) || null;
     setSelectedProgram(program);
     setSelectedStage(null);
   };
 
-  const handleStageChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+  const handleStageChange = (e: ChangeEvent<HTMLSelectElement>) => {
     const stage = selectedProgram?.stages.find((s) => s.id === Number(e.target.value)) || null;
     setSelectedStage(stage);
   };

--- a/src/components/common/NavBar.tsx
+++ b/src/components/common/NavBar.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { FaBars, FaCommentDots, FaPhoneAlt, FaSearch, FaTimes } from 'react-icons/fa'

--- a/src/components/home/FormulationStripe.tsx
+++ b/src/components/home/FormulationStripe.tsx
@@ -2,7 +2,7 @@
 
 import { motion, useScroll, useTransform } from 'framer-motion'
 import Link from 'next/link'
-import React, { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState, type ReactNode } from 'react'
 import { FaChartLine, FaDna, FaEgg, FaFire, FaLeaf, FaPiggyBank, FaShieldAlt } from 'react-icons/fa'
 import { FaCow } from 'react-icons/fa6'
 
@@ -10,7 +10,7 @@ interface Formulation {
   id: number
   name: string
   tagline: string
-  icon: React.ReactNode
+  icon: ReactNode
   color: string
   status: 'active' | 'low' | 'out'
   animals: string[]

--- a/src/components/invoice/FeedCatalogue.tsx
+++ b/src/components/invoice/FeedCatalogue.tsx
@@ -2,7 +2,7 @@
 import { Badge, Beef, Bird, Droplets, Egg, Leaf, Mail, MapPin, Phone, ShieldCheck, Sun, TestTube2, Truck, Wheat } from 'lucide-react';
 import Head from 'next/head';
 import Image from 'next/image';
-import React from 'react';
+import type { FC, ReactNode, SyntheticEvent } from 'react';
 
 interface Product {
   id: number;
@@ -14,7 +14,7 @@ interface Product {
   priceUSD: string;
   moq: string;
   image: string;
-  icon?: React.ReactNode;
+  icon?: ReactNode;
 }
 
 const getProductImage = (imagePath: string, productName: string) => {
@@ -157,8 +157,8 @@ interface ProductImageProps {
   productName: string;
 }
 
-const ProductImage: React.FC<ProductImageProps> = ({ src, alt, productName }) => {
-  const handleError = (e: React.SyntheticEvent<HTMLImageElement, Event>) => {
+const ProductImage: FC<ProductImageProps> = ({ src, alt, productName }) => {
+  const handleError = (e: SyntheticEvent<HTMLImageElement, Event>) => {
     const target = e.target as HTMLImageElement;
     target.onerror = null; // Prevents infinite loop if placeholder also fails
     target.src = `https://placehold.co/400x300/F3F3F3/333333?text=${encodeURIComponent(productName)}+Not+Found`;
@@ -182,7 +182,7 @@ interface ProductDetailsProps {
   product: Product;
 }
 
-const ProductDetails: React.FC<ProductDetailsProps> = ({ product }) => (
+const ProductDetails: FC<ProductDetailsProps> = ({ product }) => (
   <div className="flex-grow flex flex-col w-3/5 sm:w-2/3">
     {/* Product Header */}
     <div className="flex px-3 pt-3 justify-between items-start mb-1">
@@ -235,7 +235,7 @@ const ProductDetails: React.FC<ProductDetailsProps> = ({ product }) => (
 
 // --- Main ProductCard Component ---
 
-const ProductCard: React.FC<{ product: Product }> = ({ product }) => (
+const ProductCard: FC<{ product: Product }> = ({ product }) => (
   <article className="bg-white border print:border-[0.5pt] border-gray-200 overflow-hidden print:break-inside-auto transition-all duration-200 flex flex-row">
     <ProductImage
       src={getProductImage(product.image, product.name)}
@@ -246,11 +246,15 @@ const ProductCard: React.FC<{ product: Product }> = ({ product }) => (
   </article>
 );
 
-const Price = ({ children }: { children: React.ReactNode }) => <span className={`font-bold text-base text-green-700 sans-serif`}>{children}</span>;
+const Price = ({ children }: { children: ReactNode }) => (
+  <span className={`font-bold text-base text-green-700 sans-serif`}>{children}</span>
+);
 
-const ProductTitle = ({ children, className }: { children: React.ReactNode, className?: string }) => <h2 className={`sans-serif text-md font-semibold text-gray-800 leading-tight ${className}`}>{children}</h2>;
+const ProductTitle = ({ children, className }: { children: ReactNode; className?: string }) => (
+  <h2 className={`sans-serif text-md font-semibold text-gray-800 leading-tight ${className}`}>{children}</h2>
+);
 
-const CataloguePage: React.FC = () => {
+const CataloguePage: FC = () => {
   const currentYear = new Date().getFullYear();
 
   const contactItems = [

--- a/src/components/invoice/InvoiceTemplate.tsx
+++ b/src/components/invoice/InvoiceTemplate.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useState } from 'react';
+import { useState, type FC } from 'react';
 import Image from 'next/image';
 
 interface CompanyInfo {
@@ -51,7 +51,7 @@ interface InvoiceTemplateProps {
     invoiceData?: Partial<InvoiceData>;
 }
 
-const InvoiceTemplateOptimized: React.FC<InvoiceTemplateProps> = ({ invoiceData }) => {
+const InvoiceTemplateOptimized: FC<InvoiceTemplateProps> = ({ invoiceData }) => {
     // Default data
     const defaultData: InvoiceData = {
         invoiceNumber: 'INV-',

--- a/src/components/products/TechnicalSpecs.tsx
+++ b/src/components/products/TechnicalSpecs.tsx
@@ -1,10 +1,11 @@
 import { Composition } from "@/types";
+import type { FC } from 'react';
 
 interface TechnicalSpecsProps {
   compositions?: Composition[]; // Add the ? to make the property optional
 }
 
-export const TechnicalSpecs: React.FC<TechnicalSpecsProps> = ({ compositions }) => {
+export const TechnicalSpecs: FC<TechnicalSpecsProps> = ({ compositions }) => {
     return (
       <div>
         <h2 className="text-2xl font-bold text-gray-900 mb-8">Technical Specifications</h2>


### PR DESCRIPTION
## Summary
- trim unused default React imports across app and component files
- update type references to use named React types

## Testing
- `npm test` *(fails: jest not found)*
- `npx next lint` *(fails: npm ERR! 403 Forbidden - GET https://registry.npmjs.org/next)*

------
https://chatgpt.com/codex/tasks/task_e_6860a7a712dc83218d652593a2e022b8