### PR TITLE
Fix Next.js img lint warning

### DIFF
--- a/src/app/(invoice)/cv/page.tsx
+++ b/src/app/(invoice)/cv/page.tsx
@@ -4,6 +4,7 @@
 import type { FC, ReactNode } from 'react';
 import { FaDownload, FaGithub, FaLinkedin, FaEnvelope, FaGlobe, FaPhone } from 'react-icons/fa';
 import { Merriweather, Orbitron, Inter } from 'next/font/google';
+import Image from 'next/image';
 
 const inter = Inter({
   weight: '400',
@@ -201,9 +202,11 @@ export default function CVPage() {
           {/* Header */}
           <header className="mb-6 pb-4 border-b border-gray-200">
             <div className="flex flex-row gap-6 items-start">
-              <img
+              <Image
                 src="/images/kelvin.jpg"
                 alt="Kelvin Muza"
+                width={144}
+                height={144}
                 className="w-36 h-36 inline-block rounded-xl object-cover border-2 border-teal-500"
               />
 

--- a/src/app/(invoice)/resume/page.tsx
+++ b/src/app/(invoice)/resume/page.tsx
@@ -4,6 +4,7 @@
 import type { FC, ReactNode } from 'react';
 import { FaDownload, FaGithub, FaLinkedin, FaEnvelope, FaGlobe, FaPhone } from 'react-icons/fa';
 import { Merriweather, Orbitron, Inter } from 'next/font/google';
+import Image from 'next/image';
 
 const inter = Inter({
   weight: '400',
@@ -210,9 +211,11 @@ export default function CVPage() {
           {/* Header */}
           <header className="mb-6 pb-4 border-b border-gray-200">
             <div className="flex flex-row gap-6 items-start">
-              <img
+              <Image
                 src="/images/kelvin.jpg"
                 alt="Kelvin Muza"
+                width={144}
+                height={144}
                 className="w-36 h-36 inline-block rounded-xl object-cover border-2 border-teal-500"
               />
 


### PR DESCRIPTION
## Summary
- use the `next/image` component on resume and cv pages

## Testing
- `npm test` *(fails: IngredientAnalyser Service tests fail)*
- `npm run lint` *(fails: multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6860d1d242308321a7d0dfb0ad36dba1