### PR TITLE
Add Comic Neue font to admin layout

### DIFF
--- a/src/app/(admin)/layout.tsx
+++ b/src/app/(admin)/layout.tsx
@@ -6,6 +6,7 @@ import type { ReactNode } from 'react';
 
 const comicNeue = Comic_Neue({
   subsets: ['latin'],
+  weight: "400",
 });
 
 export default function AdminLayout({

--- a/src/app/(admin)/layout.tsx
+++ b/src/app/(admin)/layout.tsx
@@ -1,7 +1,12 @@
 
 import "@/app/globals.css";
 import { AnimalProvider } from "@/context/AnimalContext";
+import { Comic_Neue } from 'next/font/google';
 import type { ReactNode } from 'react';
+
+const comicNeue = Comic_Neue({
+  subsets: ['latin'],
+});
 
 export default function AdminLayout({
   children,
@@ -9,8 +14,10 @@ export default function AdminLayout({
   children: ReactNode;
 }>) {
   return (
+    <div className={comicNeue.className}>
       <AnimalProvider>
         {children}
       </AnimalProvider>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- import Comic Neue from Google Fonts
- wrap Admin layout with Comic Neue font class

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686198433e70832195b954dcceefc71a