### PR TITLE
Enable admin-only dark mode

### DIFF
--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { createContext, useContext, useEffect, useState, ReactNode } from 'react'
+import { usePathname } from 'next/navigation'
 
 type Theme = 'light' | 'dark'
 
@@ -12,27 +13,42 @@ interface ThemeContextType {
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined)
 
 export const ThemeProvider = ({ children }: { children: ReactNode }) => {
+  const pathname = usePathname()
+  const isAdmin = pathname.startsWith('/admin')
+
   const [theme, setTheme] = useState<Theme>('light')
 
-  // load saved theme
+  // load saved theme only for admin routes
   useEffect(() => {
+    if (!isAdmin) {
+      setTheme('light')
+      if (typeof document !== 'undefined') {
+        document.documentElement.classList.remove('dark')
+      }
+      return
+    }
+
     const stored = typeof window !== 'undefined' ? localStorage.getItem('theme') : null
     if (stored === 'light' || stored === 'dark') {
       setTheme(stored)
     }
-  }, [])
+  }, [isAdmin])
 
-  // apply theme class to html element
+  // apply theme class only on admin routes
   useEffect(() => {
+    if (!isAdmin) return
+
     if (typeof document !== 'undefined') {
       const root = document.documentElement
       root.classList.toggle('dark', theme === 'dark')
       localStorage.setItem('theme', theme)
     }
-  }, [theme])
+  }, [theme, isAdmin])
 
   const toggleTheme = () => {
-    setTheme(prev => (prev === 'light' ? 'dark' : 'light'))
+    if (isAdmin) {
+      setTheme(prev => (prev === 'light' ? 'dark' : 'light'))
+    }
   }
 
   return (


### PR DESCRIPTION
## Summary
- restore theme switching for admin pages
- restrict theme toggle for non-admin routes

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68619d519ef483218db21e032ede1c21